### PR TITLE
Retire gold; chapter-derived underlay palette + washi/text-fill spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ that points back to it, and `docs/AUTHORING.md` covers how to fill pages.
 
 ## What this is
 
-A **local stdio** MCP server (TypeScript, run via `tsx`) that writes the gold `ai.svg`
+A **local stdio** MCP server (TypeScript, run via `tsx`) that writes the AI `ai.svg`
 underlay into [Onionskin](https://onionskin.sitkoff.net) planner pages. The planner
 integration itself is **filesystem-only** — it reads/writes plain SVG + JSON in the app's
 iCloud container. The `fetch_image` helper is the only network-capable edge: it downloads
@@ -24,7 +24,7 @@ access.
 ## How to document (keep docs from sprawling)
 
 **Facts live in one place; everywhere else links.** The file-format contract — layers, regions,
-the gold underlay, `manifest.json`, the on-device visual parity — is owned by
+the AI underlay, `manifest.json`, the on-device visual parity — is owned by
 the Onionskin app repo's `design/FORMAT.md`; link to it rather than restating
 (duplicated facts drift). Owners in this repo: `README.md` (usage), this file
 (architecture · invariants · gotchas), `docs/AUTHORING.md` (authoring underlays + themes),
@@ -74,7 +74,7 @@ to exercise the MCP transport itself.
 | `src/paths.ts` | Container resolution (`ONIONSKIN_CONTAINER` or default iCloud path) + the **path-safety guard** (`resolvePageRel`: must be under `Shared/`, no traversal). |
 | `src/library.ts` | `requireLibrary` (existence + setup-guide error), chapter/page discovery. |
 | `src/template.ts` | Parse `template.svg` → `Region[]` geometry (transform, rect, rows/cols, ruled-line positions) with `fast-xml-parser`. |
-| `src/svg.ts` | Compose `ai.svg` from structured region input (text lines, `calendar` grid, `<image>` placement); `imageDims` header parse; gold default `GOLD` (`#9C7C1A`); per-region font/size/weight defaults; theme resolution (named presets + adaptive `{harmony,varietyDial,fontPersonality}` param block → `Theme`). |
+| `src/svg.ts` | Compose `ai.svg` from structured region input (text lines, `calendar` grid, `<image>` placement); `imageDims` header parse; the default (no-theme) underlay palette (a chapter's own resolved ink palette, gold retired); per-region font/size/weight defaults; theme resolution (named presets + adaptive `{harmony,varietyDial,fontPersonality}` param block → `Theme`). |
 | `src/color.ts` | Pure colour helpers (hex↔HSL) + `harmony` palette derivation from the template's sampled colours, with a lightness floor on derived text so it reads on cream. No deps. |
 | `src/page.ts` | Read a page, **atomic** ai.svg + `media/ai/` image writes (`resolveImages`/`gcOrphanMedia`), manifest status flips, `create_page`. |
 
@@ -106,13 +106,13 @@ drawn as a shape — no font dependency) before its text, and `wrap: true` to br
 to the region width (continuations stack below the baseline without consuming the next ruled
 row). A line may also be a `heading` (a section label) — `banner` themes draw it as a colored
 pill, `underline` themes as a label + rule. The page mood is set two ways: a named **`theme`** preset
-(`gold` default / `bright` / `cozy` / `editorial`) **or** the adaptive param block
+(`bright` / `cozy` / `editorial`, plus `gold` kept as a back-compat name — no longer a fixed colour) **or** the adaptive param block
 **`{ harmony, varietyDial, fontPersonality }`** — the chapter-theme axis whose keys are owned by
 the app's `FORMAT.md §4` (`.folder.json → theme`). `write_underlay` reads the chapter theme as the
 **default** (and `read_page` surfaces it) and accepts **per-call overrides**; `harmony` derives the
 day's palette from the template's *own sampled colours* (`src/color.ts`), `fontPersonality` swaps
-fonts (orthogonal), `varietyDial` scales banner count + heading style. Gold was only ever a default,
-not a constraint, and the orchestrator is meant to pick the mood to fit the day (see
+fonts (orthogonal), `varietyDial` scales banner count + heading style. Gold is retired — the
+default is a chapter's own ink palette, not a constraint — and the orchestrator is meant to pick the mood to fit the day (see
 `docs/AUTHORING.md`). So callers never compute
 coordinates; they reference a region name and a row index from
 `read_page`. An unknown region name throws (listing the valid ones). Raw `svg` bypasses all
@@ -187,12 +187,12 @@ pages, so catalogue instantiation is how the first page in a chapter gets made.
 - **Fonts are a closed set** (`Mulish`, `Newsreader`, `IBM Plex Mono`, `Caveat`, `Fredoka`,
   `Phosphor`) — only these render in-app; the shared `FONT_ENUM` in `index.ts` and per-region
   defaults in `svg.ts` (`REGION_DEFAULTS`) encode that. Don't introduce other font families.
-- **Legibility:** the canonical Onionskin gold is **`#9C7C1A`** (one value in the underlay, shared by
-  the app chrome, this server, and the on-device composer — `colors.css`, `Palette.swift`, `FORMAT.md`).
-  The former brand gold `#C9A227` is retired (converged 2026-06; design/DECISIONS.md #35), so the
-  server's `GOLD` is no longer a divergence. The chrome *also* defines `--gold-ink #7E5C12` (AA-tuned
-  gold for small text) — but the **underlay deliberately does not adopt that fill/text split**; it emits
-  the single `#9C7C1A` so visual parity with the on-device composer stays trivial (SHARED-VISUAL-SPEC §0).
+- **Legibility:** gold is retired entirely (design decisions, 2026-07-09) — there is no fixed
+  underlay colour any more. Every underlay text colour clears a real ≥4.5:1 WCAG contrast floor
+  against paper (`floorTextHex`/`floorAccentHex`, `contrastRatio` in `src/color.ts`), and the
+  default (no `harmony`/`accent`/preset) palette derives from the chapter's own `paletteCharacter`
+  (or the default character if unset), lifted lighter per Rule 2 — never darker than the user's own
+  ink. See `docs/SHARED-VISUAL-SPEC.md` §0 and the app's `design/INK-PALETTE.md`.
   Only the `harmony`-**derived** palette deepens text (a lightness floor at derivation, so adaptive text
   stays legible on cream — not a runtime contrast checker). Text also carries a `font-weight` (per-region default
   600, 500 for the serif `quote`; per-line `weight` override) — **confirmed honoured**, since the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ that points back to it, and `docs/AUTHORING.md` covers how to fill pages.
 
 ## What this is
 
-A **local stdio** MCP server (TypeScript, run via `tsx`) that writes the gold `ai.svg`
+A **local stdio** MCP server (TypeScript, run via `tsx`) that writes the AI `ai.svg`
 underlay into [Onionskin](https://onionskin.sitkoff.net) planner pages. Integration is **filesystem-only** —
 it reads/writes plain SVG + JSON in the app's iCloud container. There is no network API.
 
@@ -22,7 +22,7 @@ access.
 ## How to document (keep docs from sprawling)
 
 **Facts live in one place; everywhere else links.** The file-format contract — layers, regions,
-the gold underlay, `manifest.json`, the on-device visual parity — is owned by
+the AI underlay, `manifest.json`, the on-device visual parity — is owned by
 the Onionskin app repo's `design/FORMAT.md`; link to it rather than restating
 (duplicated facts drift). Owners in this repo: `README.md` (usage), this file
 (architecture · invariants · gotchas), `docs/AUTHORING.md` (authoring underlays + themes),
@@ -72,7 +72,7 @@ to exercise the MCP transport itself.
 | `src/paths.ts` | Container resolution (`ONIONSKIN_CONTAINER` or default iCloud path) + the **path-safety guard** (`resolvePageRel`: must be under `Shared/`, no traversal). |
 | `src/library.ts` | `requireLibrary` (existence + setup-guide error), chapter/page discovery. |
 | `src/template.ts` | Parse `template.svg` → `Region[]` geometry (transform, rect, rows/cols, ruled-line positions) with `fast-xml-parser`. |
-| `src/svg.ts` | Compose `ai.svg` from structured region input (text lines, `calendar` grid, `<image>` placement); `imageDims` header parse; gold default `GOLD` (`#9C7C1A`); per-region font/size/weight defaults; theme resolution (named presets + adaptive `{harmony,varietyDial,fontPersonality}` param block → `Theme`). |
+| `src/svg.ts` | Compose `ai.svg` from structured region input (text lines, `calendar` grid, `<image>` placement); `imageDims` header parse; the default (no-theme) underlay palette (a chapter's own resolved ink palette, gold retired); per-region font/size/weight defaults; theme resolution (named presets + adaptive `{harmony,varietyDial,fontPersonality}` param block → `Theme`). |
 | `src/color.ts` | Pure colour helpers (hex↔HSL) + `harmony` palette derivation from the template's sampled colours, with a lightness floor on derived text so it reads on cream. No deps. |
 | `src/page.ts` | Read a page, **atomic** ai.svg + `media/ai/` image writes (`resolveImages`/`gcOrphanMedia`), manifest status flips, `create_page`. |
 
@@ -119,13 +119,13 @@ drawn as a shape — no font dependency) before its text, and `wrap: true` to br
 to the region width (continuations stack below the baseline without consuming the next ruled
 row). A line may also be a `heading` (a section label) — `banner` themes draw it as a colored
 pill, `underline` themes as a label + rule. The page mood is set two ways: a named **`theme`** preset
-(`gold` default / `bright` / `cozy` / `editorial`) **or** the adaptive param block
+(`bright` / `cozy` / `editorial`, plus `gold` kept as a back-compat name — no longer a fixed colour) **or** the adaptive param block
 **`{ harmony, varietyDial, fontPersonality }`** — the chapter-theme axis whose keys are owned by
 the app's `FORMAT.md §4` (`.folder.json → theme`). `write_underlay` reads the chapter theme as the
 **default** (and `read_page` surfaces it) and accepts **per-call overrides**; `harmony` derives the
 day's palette from the template's *own sampled colours* (`src/color.ts`), `fontPersonality` swaps
-fonts (orthogonal), `varietyDial` scales banner count + heading style. Gold was only ever a default,
-not a constraint, and the orchestrator is meant to pick the mood to fit the day (see
+fonts (orthogonal), `varietyDial` scales banner count + heading style. Gold is retired — the
+default is a chapter's own ink palette, not a constraint — and the orchestrator is meant to pick the mood to fit the day (see
 `docs/AUTHORING.md`). So callers never compute
 coordinates; they reference a region name and a row index from
 `read_page`. An unknown region name throws (listing the valid ones). Raw `svg` bypasses all
@@ -203,12 +203,12 @@ pages, so catalogue instantiation is how the first page in a chapter gets made.
 - **Fonts are a closed set** (`Mulish`, `Newsreader`, `IBM Plex Mono`, `Caveat`, `Fredoka`,
   `Phosphor`) — only these render in-app; the shared `FONT_ENUM` in `index.ts` and per-region
   defaults in `svg.ts` (`REGION_DEFAULTS`) encode that. Don't introduce other font families.
-- **Legibility:** the canonical Onionskin gold is **`#9C7C1A`** (one value in the underlay, shared by
-  the app chrome, this server, and the on-device composer — `colors.css`, `Palette.swift`, `FORMAT.md`).
-  The former brand gold `#C9A227` is retired (converged 2026-06; design/DECISIONS.md #35), so the
-  server's `GOLD` is no longer a divergence. The chrome *also* defines `--gold-ink #7E5C12` (AA-tuned
-  gold for small text) — but the **underlay deliberately does not adopt that fill/text split**; it emits
-  the single `#9C7C1A` so visual parity with the on-device composer stays trivial (SHARED-VISUAL-SPEC §0).
+- **Legibility:** gold is retired entirely (design decisions, 2026-07-09) — there is no fixed
+  underlay colour any more. Every underlay text colour clears a real ≥4.5:1 WCAG contrast floor
+  against paper (`floorTextHex`/`floorAccentHex`, `contrastRatio` in `src/color.ts`), and the
+  default (no `harmony`/`accent`/preset) palette derives from the chapter's own `paletteCharacter`
+  (or the default character if unset), lifted lighter per Rule 2 — never darker than the user's own
+  ink. See `docs/SHARED-VISUAL-SPEC.md` §0 and the app's `design/INK-PALETTE.md`.
   Only the `harmony`-**derived** palette deepens text (a lightness floor at derivation, so adaptive text
   stays legible on cream — not a runtime contrast checker). Text also carries a `font-weight` (per-region default
   600, 500 for the serif `ainotes`; per-line `weight` override) — **confirmed honoured**, since the

--- a/README.md
+++ b/README.md
@@ -15,10 +15,15 @@ Planned work: [`docs/ROADMAP.md`](docs/ROADMAP.md) · shipped history:
 
 Every Onionskin page is a folder compositing four SVG layers
 (`template → ai → stickers → ink`). The **ai layer is yours**; the user's ink/stickers
-are not. Permission is location: only pages under `Shared/` are touchable; `Private/` is
-invisible. This server lets Claude fill a page's schedule, to-dos, focus, and the
-`ainotes` AI-voice block, then flip `manifest.json → layers.ai.status` to `ready` so the
-app composites it on next foreground.
+are not. Writing the underlay needs no permission (it isn't a privacy surface — 2026-07-09
+app decisions); the gated operation is reading the user's *ink*, per-chapter, once the app
+ships its ink-read toggle. Today the server still enforces `Shared/`-only containment
+(`Private/` is invisible) until the app retires that gate — a same-release change
+([#13](https://github.com/bsitkoff/onion_planner_mcp/issues/13)). This server lets Claude
+fill a page's schedule, to-dos, focus, and the `ainotes` AI-voice block, then flip
+`manifest.json → layers.ai.status` to `ready` so the app composites it on next foreground.
+The underlay renders in **the chapter's own colours** (its `paletteCharacter`/theme, lifted
+lighter than the user's ink and contrast-floored) — gold is retired.
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # onion-planner-mcp
 
-A local MCP server that writes the **gold AI underlay** (`ai.svg`) into
+A local MCP server that writes the **AI underlay** (`ai.svg`) into
 [Onionskin](https://onionskin.sitkoff.net) planner pages. Onionskin's whole integration surface is a
 folder of plain files in an iCloud container — no app API, no hosted service — so the core
 planner integration is **filesystem-only**: it reads `template.svg` for region geometry and

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -91,11 +91,12 @@ surface (`fill: ink`) on every template** — don't write into it; the AI's text
 fills a region" above) rather than assuming any region is yours; on a `shared` region, seed in the
 whitespace and leave the ruled lines for ink.
 
-**2. Never let the page read as blank.** A light day is honest — summer, a weekend, a quiet
-schedule — but an *empty page* looks broken. If the schedule is thin, lean into the other
-sections: fill todos, run the habit row, preview tomorrow, write a real note. A near-empty
-schedule with a rich right column and notes still feels like a planner; one lonely line in
-a 15-hour grid does not.
+**2. Never let the page read as blank — a rule, not a preference.** A light day is honest —
+summer, a weekend, a quiet schedule — but an *empty page* looks broken, and real use showed
+sparse output is the single most common way an underlay disappoints. If the schedule is thin,
+lean into the other sections: fill todos, run the habit row, preview tomorrow, write a real
+note. A near-empty schedule with a rich right column and notes still feels like a planner;
+one lonely line in a 15-hour grid does not.
 
 ## Pick a theme to fit the day
 
@@ -145,12 +146,18 @@ lavender to-dos a default, since no named preset is lavender and `harmony` only 
 template's own colours. A per-call `harmony`/preset still overrides it, and per-day exact colour
 is a line's `fill`. Derived text is always floored dark enough to read on the
 cream page — you don't need to check contrast. `harmony` takes precedence over a preset `theme`
-name; `chromeAccent` in the chapter theme is the app's chrome concern and is ignored here.
+name. `chromeAccent` in the chapter theme is the chapter's accent colour (also the app's
+live/refreshing signal colour): here it becomes the default **washi-block tint**, so duration
+blocks echo the chapter's accent.
 
 **Themes are defaults, not a lock — any color is yours.** Override a banner's color with a
 region's `labelFill` (region title) or a heading line's `fill` (sub-section), and body text
 with a line's `fill` — any hex. So an overnight job can drive an exact palette: e.g. all
-banners as lighter→darker shades of one hue for a subdued, "same-family" look. Note: the app
+banners as lighter→darker shades of one hue for a subdued, "same-family" look. Two things to
+know: **pick per-line fills from `read_page`'s `underlay` palette** (the resolved, already
+lifted-and-floored chapter colours) so your overrides stay in the chapter's family; and any
+colour drawn **as text** is auto-darkened to the ≥4.5:1 contrast floor (a raw hex passes
+through untouched only on no-text fills — washi tints, banner pills, markers). Note: the app
 renders **solid fills only** — no SVG gradients — so approximate a gradient with a family of
 solids.
 
@@ -178,6 +185,14 @@ content — no "Habits" header on a day you're not tracking habits.
 Box regions flow top-down, so heading → items → next heading stack naturally; you don't
 compute any `y`. Headings ignore `marker`/`wrap` (they're labels).
 
+**Hard rule: one text box per logical block — never one per line.** A logical block (a
+note's paragraph, a to-do, an event label) is ONE `lines[]` entry, with wrapping doing the
+line-breaking (`wrap` is on by default for flow-placed body lines). Never pre-split a
+sentence across several entries to control its line breaks: those entries are independent
+boxes, so when a word is later added or the text is edited, nothing reflows — lines overlap
+or leave holes. Separate entries are for separate *things* (each to-do, each event), not for
+the visual lines of one thing.
+
 ## Use the placement the server already does for you
 
 - **Schedule by clock time, not coordinates.** Give each line a `time: "HH:MM"`; the server
@@ -192,8 +207,12 @@ compute any `y`. Headings ignore `marker`/`wrap` (they're labels).
   calendar event with a real start and end should be a block: a column of bare one-line labels
   on a 15-row grid reads sparse and unfinished, while blocks fill the hours the day actually
   holds. Reserve a bare `time` line for genuine point-in-time notes (a reminder, a deadline, a
-  drop-off). Tint defaults to the theme's accent colour; override per-block with
-  `blockFill`/`blockOpacity`. `endTime`/`durationMin` without a `time` start is ignored
+  drop-off). Tint defaults to the **chapter's `chromeAccent`** (else the theme's accent),
+  drawn at a soft 0.16 opacity with an 8px radius; override per-block with
+  `blockFill`/`blockOpacity`. **Block dimensions come from the template's geometry** — the
+  minimum height is one schedule-line interval read from the template's ruled lines, so even
+  a 20-minute meeting draws a visible tape (info `washi_block_min_height`) instead of a bare
+  line. `endTime`/`durationMin` without a `time` start is ignored
   (mirrors how `marker`/`wrap` are ignored on a heading). A long event name wraps to fit the
   block automatically — no need to shorten it or pass `wrap` yourself.
 - **`marker`** — `checkbox` for todos/habits, `bullet` for note items. Drawn shapes, no font
@@ -214,7 +233,9 @@ compute any `y`. Headings ignore `marker`/`wrap` (they're labels).
   media-resolved, so use the structured `images` array for art. Reach for this rarely — the
   structured placement above is what keeps you aligned to the geometry.
 - **`merge: true`** — a mid-day "update my planner" patches only the regions you pass and
-  leaves the rest verbatim (slide a new meeting in without clearing the to-dos).
+  leaves the rest verbatim (slide a new meeting in without clearing the to-dos). Verbatim
+  includes colours: a region last written under an older palette (e.g. the retired gold)
+  keeps those colours until you rewrite that region — intentional, not a bug.
 - **Write once, then check `warnings`.** A real `write_underlay` returns the same `warnings`
   a `dryRun` would, so you don't need a separate preview pass — and emitting the whole
   `regions` payload twice is the slowest part of an unattended run. Write with status `ready`,

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -24,7 +24,7 @@ its level; don't fight it.**
   Tomorrow) uses a line with `heading`.
 - **`styled: true`** (it prints its own colour-filled banners, or ships a `stickers.svg`): it did the
   decorating. *Fill quietly into the existing slots* — no competing banners, little or no
-  added art. And don't fall back to drab gold: **use `template.palette`** (the template's own
+  added art. And don't fall back to a flat default: **use `template.palette`** (the template's own
   accent colors) for your text/markers so the fill harmonizes with the design.
 
 When in doubt, under-decorate — the user chose that template on purpose.
@@ -109,13 +109,13 @@ from a wide-open summer beach day.
 | `bright` | lively, saturated banners | a fun, light, or celebratory day |
 | `cozy` | warm, hand-painted | a calm, rainy, or homebound day |
 | `editorial` | restrained, quiet labels | a heads-down, focused work day |
-| `gold` | quiet monochrome (default) | when you want the underlay to recede |
+| `gold` | back-compat name for the default (the chapter's own ink palette) | when you want the underlay to recede |
 
 > **Two axes — theme vs template style.** Your `theme` is the underlay's *mood* (the day's
 > content). It is independent of the *template's* **style** — `minimal / cozy / colorful`, how
 > rich the printed page already is (visible in the template's id/name, and surfaced as the
 > `styled` flag + `palette` in the page summary). They pair naturally — **minimal ↔
-> `gold`/`editorial`, cozy ↔ `cozy`, colorful ↔ `bright`** — so a sensible default is to echo a
+> the default/`editorial`, cozy ↔ `cozy`, colorful ↔ `bright`** — so a sensible default is to echo a
 > styled template with the matching theme (or its own `palette`), then deviate when the day calls
 > for it. A loud theme on an already-colorful template competes; a quiet theme lets it breathe.
 
@@ -158,7 +158,7 @@ solids.
 
 The template stays **minimal on purpose** (a neutral scaffold; see the
 [minimal-template principle](MCP-INTEGRATION.md)). *You* add the structure a given day
-needs, in the gold layer, so pages differ day to day. Inside a neutral box region (e.g.
+needs, in the AI layer, so pages differ day to day. Inside a neutral box region (e.g.
 `notes`), use `heading: true` to draw a section label (bold, letter-spaced, with a hairline
 rule); the lines after it flow below as its items. Only emit a section on the days it has
 content — no "Habits" header on a day you're not tracking habits.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,57 @@ roadmap holds only planned feature development (bugs/polish live on the
 
 ---
 
+## Gold retired — the underlay renders in the chapter's colours — 2026-07-09
+
+The app's 2026-07-09 colour-model rewrite lands server-side (issues #18/#19/#20; decision
+text: `onionskin/design/handoff-decisions-2026-07-09/decisions-source.md`; spec owner
+`design/UNDERLAY-VISUAL.md` forthcoming, onionskin#23). Gold (`#9C7C1A`) is no longer a
+fixed seed anywhere — no `GOLD` constant, no gold preset colour, no gold fallback.
+
+- **Chapter-derived default palette.** With no `harmony`/`accent`/preset override, the
+  underlay palette derives from the chapter's `paletteCharacter` (`.folder.json → theme`,
+  additive key; 5 ink hexes mirrored from the app's `InkPalette.swift`), lifted lighter than
+  the user's ink by one constant (`liftForUnderlay`, offset 0.14) and clamped at a real
+  WCAG ≥4.5:1 contrast floor on paper — the three underlay-palette rules. `theme: "gold"`
+  survives only as a back-compat *name* that resolves to this dynamic default.
+- **Rule 1 on per-line overrides.** Any caller-supplied colour drawn *as text* (a line's
+  `fill`, an underline label's `labelFill`, calendar day numbers) is auto-darkened to the
+  floor; raw hex passes through untouched only on no-text fills (washi tint, banner pills,
+  markers/icons).
+- **Washi blocks follow the 2026-07-09 spec.** `rx` 6→8, default tint opacity 0.22→0.16;
+  the tint now defaults to the **chapter's `chromeAccent`** (else `theme.accent`); and the
+  **minimum block height is one schedule-line interval read from the template's ruled
+  lines** (info `washi_block_min_height`) — a sub-interval or backwards span draws a visible
+  minimum tape instead of degrading to a bare time line, superseding #17's fallback (which
+  now survives only for an event starting on the grid's last ruled line, where no block fits).
+- **New chapter-theme keys (additive):** `customInk1`/`customInk2` (extra ink slots appended
+  to the character's 5-ink pool — the app's 7-slot tray) and `displayName` (advisory), on
+  `set_chapter_theme` and `ChapterTheme`. A chapter's `paletteCharacter` outranks the
+  chapter's own `harmony`/`varietyDial` (its colour identity wins), while per-call adaptive
+  params still override everything.
+- **`read_page` returns `underlay`** — the resolved (lifted + floored) palette a default
+  write will use (`text`/`serif`/`accent`/`banners`/`headingStyle`/`washiTint`), computed by
+  the exact `resolveThemeInput → resolveTheme` path `write_underlay` takes, so the advertised
+  and composed palettes can't drift. Orchestrators should pick per-line `fill`s from it.
+- **`merge` keeps old colours verbatim** — a region last written under the old gold stays
+  gold until that region is rewritten. Intentional (merge preserves untouched regions
+  byte-for-byte), documented in `AUTHORING.md`.
+- Docs: `AUTHORING.md` gains the **one-text-box-per-logical-block hard rule** (#18), the
+  template-driven washi geometry, and the sparse-day rule framing; `MCP-INTEGRATION.md`
+  states the 2026-07-09 permission model (underlay writes ungated; `read_ink` gated by the
+  app's per-chapter ink-read toggle once it ships — `resolvePageRel`'s Shared/ containment
+  stays until the app retires the gate, #13); `SHARED-VISUAL-SPEC.md` §7 + resolved-decisions
+  updated to the new washi/palette facts.
+
+**Needs-confirm (design proposals, not final tokens):** the pre-lighten offset **0.14**
+(`liftForUnderlay`), the six palette-character ids + 30 ink hexes (hand-mirrored from the
+app worktree's `InkPalette.swift`), the monthly-ink formula (`monthlyInks`, exported but
+unwired), and the ink-read toggle's `FORMAT.md` key name (undecided app-side).
+
+Smoke 279 checks, all passing · tsc clean.
+
+---
+
 ## Washi-tape blocks widened + long labels wrap — 2026-07-06
 
 The schedule's washi-tape duration block was subtracting its wide *left* gutter (reserved for

--- a/docs/MCP-INTEGRATION.md
+++ b/docs/MCP-INTEGRATION.md
@@ -14,7 +14,7 @@ are, what to write, and the rules.
 ## 1. The one-paragraph model
 
 Every page is a **folder**. A page composites four SVG layers in z-order:
-`template.svg` (graphite grid + addressable regions) → **`ai.svg` (gold — yours to
+`template.svg` (graphite grid + addressable regions) → **`ai.svg` (yours to
 write)** → `stickers.svg` (pink — the user's) → `ink.svg` (blue — the user's
 handwriting). **Permission is location:** a page under `Shared/` may be read and written
 by the user's AI; everything else is private. Your entire job is: **write `ai.svg` in a
@@ -122,9 +122,10 @@ label + rule, with its items flowing below). Don't ask for a richer template; co
 richness into `ai.svg`.
 
 ### c. Write `ai.svg`
-Emit one self-contained SVG on the page's `viewBox`. Gold is `#9C7C1A` — the single canonical
-Onionskin gold (shared by the app chrome, this server, and the on-device composer; deepened for
-legibility on white paper). This is what the reference server emits by default. Group your
+Emit one self-contained SVG on the page's `viewBox`. Gold is retired — the default palette
+derives from the chapter's own `paletteCharacter` (or a calm blue-family default), lifted lighter
+than the user's ink and floored to a real ≥4.5:1 contrast on paper. This is what the reference
+server emits by default. Group your
 output by region so it's legible:
 
 ```xml

--- a/docs/MCP-INTEGRATION.md
+++ b/docs/MCP-INTEGRATION.md
@@ -16,9 +16,19 @@ are, what to write, and the rules.
 Every page is a **folder**. A page composites four SVG layers in z-order:
 `template.svg` (graphite grid + addressable regions) → **`ai.svg` (yours to
 write)** → `stickers.svg` (pink — the user's) → `ink.svg` (blue — the user's
-handwriting). **Permission is location:** a page under `Shared/` may be read and written
-by the user's AI; everything else is private. Your entire job is: **write `ai.svg` in a
-shared page, then mark it ready.** That's the whole "connection."
+handwriting). Your entire job is: **write `ai.svg` in a shared page, then mark it ready.**
+That's the whole "connection."
+
+**Permission model (2026-07-09 decisions):** the AI underlay is **not a privacy surface** —
+*writing* `ai.svg` needs no permission gating. The only gated operation is *reading the
+user's ink layer* (`read_ink`), which will be governed by the app's **per-chapter ink-read
+toggle** once it ships (the toggle's `FORMAT.md` key name is still TBD app-side; until then
+`read_ink` works everywhere under `Shared/`). The old location-based gate — "`Shared/` is
+readable/writable, everything else is private" — is retiring **app-side**, but the server's
+`resolvePageRel` guard still enforces `Shared/` containment today: dropping it is a
+same-release change coupled to the app shipping the gate retirement
+([#13](https://github.com/bsitkoff/onion_planner_mcp/issues/13)) — do not remove the guard
+unilaterally.
 
 ---
 
@@ -131,11 +141,12 @@ output by region so it's legible:
 ```xml
 <svg viewBox="0 0 1024 1366" xmlns="http://www.w3.org/2000/svg">
   <g data-region="schedule">
-    <text x="86" y="284" font-family="Mulish" font-size="14" fill="#9C7C1A">04:00  pill alarm</text>
-    <text x="86" y="362" font-family="Mulish" font-size="14" fill="#9C7C1A">09:00  standup</text>
+    <!-- fills come from the chapter's derived palette (these are the blue-family default's) -->
+    <text x="86" y="284" font-family="Mulish" font-size="14" fill="#4f76b0">04:00  pill alarm</text>
+    <text x="86" y="362" font-family="Mulish" font-size="14" fill="#4f76b0">09:00  standup</text>
   </g>
   <g data-region="ainotes">
-    <text x="80" y="1204" font-family="Newsreader" font-size="26" fill="#9C7C1A">I am capable of embracing change.</text>
+    <text x="80" y="1204" font-family="Newsreader" font-size="26" fill="#2f8086">I am capable of embracing change.</text>
   </g>
 </svg>
 ```

--- a/docs/ON-DEVICE-UNDERLAY.md
+++ b/docs/ON-DEVICE-UNDERLAY.md
@@ -54,13 +54,13 @@ cut-out — the grey-background knockout currently lives only in the MCP-side im
 ## The collaboration point — visual parity
 
 The on-device path doesn't need this MCP's engine; it needs to **look consistent** with MCP
-output on the regions it fills — gold values, fonts, `label`/`heading` style, spacing, region
+output on the regions it fills — the resolved palette, fonts, `label`/`heading` style, spacing, region
 layout. That visual spec, not a shared codebase, is the contract between the two authors.
 
 **The spec is now locked** in [`SHARED-VISUAL-SPEC.md`](SHARED-VISUAL-SPEC.md) (parity decisions
 resolved 2026-06) and its agreed parts (§0–4 + markers) are mirrored into
 `../onionskin/design/FORMAT.md`. The on-device composer matches it on its subset (schedule
 agenda, to-do text, note band, monthly markers) and draws **no banners** (§5 is MCP-only). Key
-resolved points for this author: one canonical gold `#9C7C1A`; schedule is agenda-style (no
+resolved points for this author: the chapter's own ink palette, lifted for the underlay (gold is retired); schedule is agenda-style (no
 printed hour labels); write to-do **text only** where the template prints its own checkboxes;
-render **one quiet gold style**, not a per-day theme.
+render **one quiet default style**, not a per-day theme.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,9 +30,11 @@ below links its issue — detail, sketches, and open decisions live there, not h
    ([onionskin#144](https://github.com/bsitkoff/onionskin/issues/144)) once it ships. The
    app-side Shared/ visibility gate retires with it (see [#13](https://github.com/bsitkoff/onion_planner_mcp/issues/13)).
 4. **No gold** (app design decisions 2026-07-09) — the default decoration palette derives
-   from the chapter's palette character / `theme.harmony`, not a canonical gold token; this
-   supersedes `SHARED-VISUAL-SPEC.md` §0's gold value when
-   [#20](https://github.com/bsitkoff/onion_planner_mcp/issues/20) lands.
+   from the chapter's palette character / `theme.harmony`, not a canonical gold token.
+   **Shipped** ([#20](https://github.com/bsitkoff/onion_planner_mcp/issues/20), 2026-07-09);
+   `SHARED-VISUAL-SPEC.md` §0 now records the three underlay-palette rules instead. The
+   palette-character names/hexes and the pre-lighten offset (0.14) remain a **design
+   proposal pending Bridget's confirmation** (see CHANGELOG).
 
 ### Invariants every item must respect
 
@@ -54,21 +56,12 @@ below links its issue — detail, sketches, and open decisions live there, not h
 
 ## Planned — near-term
 
-From the app's 2026-07-09 design decisions
-(`onionskin/design/handoff-decisions-2026-07-09/decisions-source.md`):
-
-1. **Text boxes: one box per logical block, never one per line** — hard authoring rule
-   (`docs/AUTHORING.md`); today's one-box-per-line output can't reflow when a word is added.
-   **Blocks daily use — top of the list.**
-   [#18](https://github.com/bsitkoff/onion_planner_mcp/issues/18)
-2. **Washi/duration blocks: dimensions derive from template geometry** — min block height =
-   one schedule-line interval *read from the template*, never a hardcoded min-height. Gated
-   on the app's `design/UNDERLAY-VISUAL.md` (onionskin#23).
-   [#19](https://github.com/bsitkoff/onion_planner_mcp/issues/19)
-3. **Underlay default palette is chapter-derived, not gold** — gold is retired app-wide;
-   derive from palette character / `harmony`, enforce the shared contrast-floor +
-   pre-lightened-ceiling rules; revise `SHARED-VISUAL-SPEC.md` §0 in coordination.
-   [#20](https://github.com/bsitkoff/onion_planner_mcp/issues/20)
+The app's 2026-07-09 design-decision items
+(`onionskin/design/handoff-decisions-2026-07-09/decisions-source.md`) — one-box-per-block
+authoring ([#18](https://github.com/bsitkoff/onion_planner_mcp/issues/18)),
+template-geometry washi sizing ([#19](https://github.com/bsitkoff/onion_planner_mcp/issues/19)),
+and the chapter-derived palette ([#20](https://github.com/bsitkoff/onion_planner_mcp/issues/20))
+— **shipped 2026-07-09**; see `CHANGELOG.md`.
 
 Friction from the 2026-07-05 morning-run audit, ordered by leverage for the unattended
 nightly/morning runs:

--- a/docs/SHARED-VISUAL-SPEC.md
+++ b/docs/SHARED-VISUAL-SPEC.md
@@ -11,27 +11,36 @@
 
 ## 0. Global tokens
 
-- **Gold — `#9C7C1A`, canonical (one value in the underlay).** Shared by the app chrome, this
-  MCP, and the on-device composer (`colors.css`, `Palette.swift`, `FORMAT.md`). The former brand
-  gold `#C9A227` is retired (converged 2026-06; `../onionskin/design/DECISIONS.md` #35). It is
-  deepened so AI text stays legible on the cream page.
-  - *Note (2026-06 redesign review):* the **chrome** additionally defines `--gold-ink #7E5C12`,
-    an AA-tuned gold for *small text on light* (distinct from `--gold-1 #9C7C1A`, used for fills).
-    The **underlay deliberately does not adopt the split** — both authors emit the single
-    `#9C7C1A` here, so visual parity stays trivial. (The underlay text we emit is bold/large
-    enough that `#9C7C1A` clears AA-large on cream; the second token is a chrome concern.)
+- **Gold is retired entirely (design decisions, 2026-07-09).** There is no fixed underlay colour
+  any more — no `#9C7C1A`, no chrome-signal gold, no seed either author defaults to. The
+  live/refreshing chrome signal is the app's per-chapter chrome accent (`chromeAccent`), not a
+  colour this contract governs. Both underlay authors instead follow the three rules below,
+  enforced at the token layer (see the app's `design/INK-PALETTE.md`):
+  1. **Contrast floor** — any underlay TEXT colour clears **≥4.5:1 WCAG contrast** on
+     `paper-0`/cream. Auto-darken to reach it (`floorTextHex`/`floorAccentHex`,
+     `contrastRatio` in `src/color.ts`); raw hex is fills-only.
+  2. **Pre-lightened underlay** — the underlay receives each ink colour from the chapter's own
+     resolved palette, lifted lighter by a fixed HSL offset (`liftForUnderlay`), clamped so the
+     lift never drops contrast below the floor. One rule, two guarantees: the underlay is always
+     lighter than the user's own handwriting, and always readable.
+  3. **No reserved colours** — the underlay may use any colour from its derived (lightened)
+     palette; a clash with the user's ink is resolved by regenerating, never prevented up front.
+  - The **default** palette (no `harmony`/`accent`/preset `theme`) derives from the chapter's own
+    `paletteCharacter` (design/INK-PALETTE.md — a design proposal, names/hexes may change), or a
+    calm blue-family default character if none is set. `theme: "gold"` is kept only as a
+    back-compat preset **name** — it resolves to this same default, not a fixed colour.
 - **Fonts (closed set):** `Mulish` (sans), `Newsreader` (serif), `IBM Plex Mono` (mono),
   `Caveat`, `Fredoka`, `Phosphor` (icons). Unknown families fall back to the serif.
 - **Defaults:** body weight `600`; left inset `24px` from a region's left edge.
 - **Solid fills only** (the renderer has no gradient support).
 - **Two style axes (don't conflate):** a *template's* **style** — `minimal / cozy / colorful`,
   how rich the printed page is — is independent of the *underlay's* **theme** (§6), the day's
-  mood. They pair naturally (minimal ↔ gold/editorial, cozy ↔ cozy, colorful ↔ bright) but are
-  separate vocabularies on purpose.
+  mood. They pair naturally (minimal ↔ the default/editorial mood, cozy ↔ cozy, colorful ↔
+  bright) but are separate vocabularies on purpose.
 
 ## 1. Schedule (agenda)
 
-- Text: **Mulish 15 / weight 600 / gold**.
+- Text: **Mulish 15 / weight 600 / the resolved theme colour** (default: the chapter's own ink palette, lifted — gold retired).
 - **Resolved — no template prints hour labels.** Verified across the catalogue (e.g.
   `daily-minimal` exposes `region-schedule` as ruled rows only, no `HH:00` gutter). So the
   schedule reads as a **sequential agenda**: place items by `row` (snap to a ruled line), or by
@@ -43,19 +52,19 @@
 
 ## 2. To-do list
 
-- Text: **Mulish 15 / 600 / gold**.
+- Text: **Mulish 15 / 600 / the resolved theme colour**.
 - **Resolved — most templates print their own checkbox squares.** Verified: `todo-*` print a
   full column of `26×26` boxes; `daily-cozy` / `daily-colorful` print ~7 in their to-do region;
   `daily-minimal` prints none (ruled rows only). **Rule: inspect the template.** If it prints
   boxes, the author writes **text only**, aligned to the ruled rows — do *not* also draw a marker
   (that yields double boxes). If it prints none, the author may draw `marker: "checkbox"`.
 - Checkbox marker (when author-drawn): square, side `round(0.85 × size)`, stroke
-  `max(1, round(size/12))`, corner `rx 2`, `fill none`, gold stroke; box top = `baseline −
+  `max(1, round(size/12))`, corner `rx 2`, `fill none`, themed stroke; box top = `baseline −
   side`; text starts at `box + round(0.4 × size)` past the left inset.
 
 ## 3. Note band
 
-- Text: **Mulish 14 / 600 / gold**.
+- Text: **Mulish 14 / 600 / the resolved theme colour**.
 - **Resolved — wrap is on for free-text regions** (`ainotes`, and any unruled AI box). Stacking: first-line top
   pad `≈ 1.2 × size`; line leading `≈ 1.5 × size`; wrapped continuations `≈ 1.3 × size` below the
   baseline (they don't consume the next ruled row). Geometry follows the region `<rect>` (a single
@@ -66,13 +75,13 @@
 - **Resolved — templates ship a blank grid, no printed day numbers.** Verified: `monthly-*`
   expose `region-month` with `data-cols="7" data-rows="6"` and no numbers. So an author (the app's
   default seed, or the MCP) draws the numbers **and** the tap targets:
-- Day number: **Mulish 18 / 600 / accent (gold)**, at cell top-left — `x = cellLeft + 8`,
+- Day number: **Mulish 18 / 600 / accent** (the resolved theme colour), at cell top-left — `x = cellLeft + 8`,
   `baseline = cellTop + 18 + 4`.
 - Event label: **Mulish 12 / 500 / accent**, under the number (`baseline + 12 + 6`).
 - Tap target: `<rect data-date="YYYY-MM-DD" fill="none">` covering the cell. **Both authors must
   emit this identically** — Sunday-start, matching the `SUN…SAT` headers.
-- Event marker style: a small gold **dot** (`r 4`) on days with events, plus the optional text
-  label; gold, not by-event-type (keep it quiet — the page styling carries the colour).
+- Event marker style: a small themed **dot** (`r 4`) on days with events, plus the optional text
+  label; the resolved theme colour, not by-event-type (keep it quiet — the page styling carries the colour).
 
 ## 5. Banners / labels / headings — MCP only (reference)
 
@@ -97,9 +106,10 @@
 The underlay mood is drivable two ways, both *defaults, not law* (any banner/text color is
 overridable per element):
 
-1. **Named presets** (quick pick / back-compat): `gold` (mono, underline headings), `bright`
-   (teal/coral/pink/grape banners, `#3A3A3A` ink), `cozy` (rose/sage/gold/plum, `#4A4A4A` ink),
-   `editorial` (terracotta/greige, underline).
+1. **Named presets** (quick pick): `bright` (teal/coral/pink/grape banners, `#3A3A3A` ink),
+   `cozy` (rose/sage/amber/plum, `#4A4A4A` ink), `editorial` (terracotta/greige, underline).
+   `gold` is kept as a back-compat preset **name** only — it no longer emits a fixed colour;
+   it resolves to the same default-ink-palette theme as no preset at all.
 2. **The adaptive param block** — `{ harmony, varietyDial, fontPersonality }`, the chapter-theme
    axis. **The contract keys are owned by the app's `FORMAT.md §4`** (`.folder.json → theme`); not
    restated here. MCP-side consumption:
@@ -112,7 +122,7 @@ overridable per element):
      (`<0.4` → quiet underline, else banner pills).
    - **`fontPersonality`** (`clean`/`handwritten`/`editorial`) swaps font families only (within the
      closed set: `clean`=Mulish/Newsreader, `handwritten`=Caveat/Fredoka, `editorial`=Newsreader-led)
-     — an **orthogonal axis**, layered on any palette including the gold default.
+     — an **orthogonal axis**, layered on any palette including the default.
    - **`chromeAccent`** is the app's concern (chrome only) — accepted and ignored.
 
 `write_underlay` reads the chapter theme as the **default** and accepts per-call **overrides**
@@ -120,9 +130,9 @@ overridable per element):
 to the on-device composer.
 
 > **Resolved — the MCP picks a per-day theme; the on-device sibling renders one quiet style**
-> (the canonical gold, matched to the template). The MCP's theme is the underlay *mood* axis and
-> is independent of the template's *style* (§0). The orchestrator picks the theme to fit the day,
-> or sets it once on the chapter (see `AUTHORING.md`).
+> (the chapter's own ink palette, matched to the template). The MCP's theme is the underlay
+> *mood* axis and is independent of the template's *style* (§0). The orchestrator picks the theme
+> to fit the day, or sets it once on the chapter (see `AUTHORING.md`).
 
 ## 7. Washi-tape schedule blocks — MCP only
 
@@ -148,20 +158,24 @@ zero/negative-duration span isn't drawn at all (warns `washi_block_zero_duration
 
 ## Resolved decisions (consolidated)
 
-1. **Gold:** `#9C7C1A` is canonical everywhere; `#C9A227` retired. (§0)
+1. **Gold is retired:** no fixed underlay colour anywhere. Three rules instead — contrast floor
+   (≥4.5:1 on paper), pre-lightened underlay (lifted from the chapter's own ink palette, clamped
+   at the floor), no reserved colours. Default palette source is the chapter's `paletteCharacter`.
+   (§0)
 2. **Schedule:** no template prints hour labels → agenda placement (`row`, or `time` via
    `startHour`/`rowsPerHour`); the 52px inset is now just a margin. (§1)
 3. **To-do:** most templates print their own checkboxes → author writes **text only** there;
    draw a marker only when the template prints none. (§2)
 4. **Note band:** wrap **on** for `ainotes` (free-text AI box); geometry from the region rect. (§3)
 5. **Monthly:** templates print no day numbers → author draws numbers + `data-date` rects;
-   marker = gold dot (+ optional label). (§4)
+   marker = a themed dot (+ optional label). (§4)
 6. **Banners:** MCP draws them; on-device is content-only. (§5)
 7. **Theme:** the underlay mood is set by named presets *or* the adaptive `{ harmony, varietyDial,
    fontPersonality }` block (chapter `.folder.json → theme`, keys owned by app `FORMAT.md §4`);
    `write_underlay` reads the chapter theme as default + accepts per-call overrides. MCP picks the
    per-day theme; on-device renders one quiet/matched style. Template *style* and underlay *theme*
-   stay independent axes. Underlay gold stays the single `#9C7C1A` (no fill/text split). (§0, §6)
+   stay independent axes. Underlay colour is the chapter's own ink palette, lifted lighter — never
+   a fixed seed (gold retired). (§0, §6)
 8. **Washi-tape schedule blocks:** MCP-only, drawn via `time`+`endTime`/`durationMin`; tint
    defaults to `theme.accent`, `fill-opacity` default 0.22, `rx 6` reusing §5's corner radius;
    right inset is the standard margin (not the schedule's own wider left gutter); an overlong

--- a/docs/SHARED-VISUAL-SPEC.md
+++ b/docs/SHARED-VISUAL-SPEC.md
@@ -140,21 +140,26 @@ to the on-device composer.
 > underlay-authored, matching the app renderer's confirmed support for `rx` + `fill-opacity`.
 
 A schedule line with `time` + (`endTime` or `durationMin`) draws a block instead of a single
-baseline: rounded `<rect rx="6">` (reusing §5's one corner-radius convention) with
-`fill-opacity` (default **0.22**, a translucent "tape" tint) instead of a solid fill — the only
-element in this file to use `fill-opacity` rather than `opacity`. Tint defaults to the chapter's
-`theme.accent` (the same per-line-override pattern as a label's `labelFill` over
-`theme.banners[...]`), overridable per-block via `blockFill`. The label text sits vertically
-centred inside the block at `y1 + height − round(height × 0.28)` — the same centring ratio as
-§5's label-slot text. Left inset = the region's `xPad` (the schedule's gutter for its printed
-hour labels); right edge = `region.width − DEFAULT_X_PAD`, the *standard* margin — not the
-region's (often wider) `xPad` again, which would double-charge the left gutter on a side that
-has no hour labels to clear. A label too long to fit the block's width on one line wraps
+baseline: rounded `<rect rx="8">` with `fill-opacity` (default **0.16**, a translucent "tape"
+tint) instead of a solid fill — the only element in this file to use `fill-opacity` rather than
+`opacity`. Radius + opacity follow the 2026-07-09 washi spec (owner: the app repo's
+`design/UNDERLAY-VISUAL.md`, forthcoming — onionskin#23). Tint defaults to the chapter's
+**`chromeAccent`** (the chapter's accent colour — a no-text fill, so it rides through raw),
+falling back to `theme.accent`, overridable per-block via `blockFill`. The label text sits
+vertically centred inside the block at `y1 + height − round(height × 0.28)` — the same centring
+ratio as §5's label-slot text. Left inset = the region's `xPad` (the schedule's gutter for its
+printed hour labels); right edge = `region.width − DEFAULT_X_PAD`, the *standard* margin — not
+the region's (often wider) `xPad` again, which would double-charge the left gutter on a side
+that has no hour labels to clear. A label too long to fit the block's width on one line wraps
 (reusing the same wrap heuristic as `ainotes`/`todo`), stacking centred within the block's
 height; if the wrapped lines still don't fit the block's height it warns
 `washi_block_label_overflow` rather than silently overrunning. A span partly outside the
-region's ruled grid is pinned to fit and still drawn (warns `washi_block_clamped`); a
-zero/negative-duration span isn't drawn at all (warns `washi_block_zero_duration`).
+region's ruled grid is pinned to fit and still drawn (warns `washi_block_clamped`).
+**Minimum block height is one schedule-line interval, read from the template's ruled lines** —
+a span too short to cross a ruled row (a 20-min meeting on a 1-row-per-hour grid, or a
+backwards range) is drawn at the one-interval minimum (info `washi_block_min_height`) rather
+than degrading to a bare time line; only an event starting on the grid's *last* ruled line,
+where no block can fit, falls back to a plain time line (info `washi_block_zero_duration`).
 
 ## Resolved decisions (consolidated)
 
@@ -177,7 +182,8 @@ zero/negative-duration span isn't drawn at all (warns `washi_block_zero_duration
    stay independent axes. Underlay colour is the chapter's own ink palette, lifted lighter — never
    a fixed seed (gold retired). (§0, §6)
 8. **Washi-tape schedule blocks:** MCP-only, drawn via `time`+`endTime`/`durationMin`; tint
-   defaults to `theme.accent`, `fill-opacity` default 0.22, `rx 6` reusing §5's corner radius;
-   right inset is the standard margin (not the schedule's own wider left gutter); an overlong
-   label wraps into the block before anything warns; span overflow clamps and warns rather than
-   distorting the grid. (§7)
+   defaults to the chapter's `chromeAccent` (else `theme.accent`), `fill-opacity` default 0.16,
+   `rx 8` (2026-07-09 washi spec); right inset is the standard margin (not the schedule's own
+   wider left gutter); an overlong label wraps into the block before anything warns; span
+   overflow clamps and warns rather than distorting the grid; min block height = one
+   schedule-line interval read from the template (never a hardcoded minimum). (§7)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onion-planner-mcp",
   "version": "1.0.0",
-  "description": "MCP server that writes the gold AI underlay into Onionskin planner pages (filesystem-only iCloud integration)",
+  "description": "MCP server that writes the AI underlay into Onionskin planner pages (filesystem-only iCloud integration)",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/src/color.ts
+++ b/src/color.ts
@@ -3,11 +3,22 @@
  * palette from a template's sampled colours (`template.palette`) per the chapter
  * theme's `harmony` strategy. Pure functions, no deps.
  *
- * The one hard rule lives here, not in a runtime checker: **derived *text* colours
- * are floored dark** (`TEXT_L_MAX`) so they always read on the cream page. We don't
- * draw the paper — the template does — so legibility is solved once, at derivation,
- * rather than warned about per-write. Fills/banners get a different, lighter bound
- * (they sit behind white pill text). See `docs/SHARED-VISUAL-SPEC.md` §0/§6.
+ * Gold is retired (design decisions, 2026-07-09) — there is no fixed seed colour any
+ * more. The default palette derives from a chapter's own **palette character**
+ * (`PALETTE_CHARACTERS` below), same catalogue as the app's `InkPalette.swift`.
+ *
+ * The underlay-palette rules (design/INK-PALETTE.md, mirrored from the sibling app
+ * repo's contract) are enforced here, not in a runtime checker:
+ *  - **Rule 1 — contrast floor**: any underlay TEXT colour clears ≥4.5:1 WCAG
+ *    contrast against `PAPER_COLOR` (`floorTextHex`/`floorAccentHex`, now real WCAG
+ *    math via `contrastRatio`, replacing the old hand-tuned lightness bands).
+ *  - **Rule 2 — pre-lightened underlay**: `liftForUnderlay` lifts an ink colour
+ *    lighter by a fixed offset, clamped so the lift never drops contrast below the
+ *    floor — one rule, two guarantees.
+ *  - **Rule 3 — no reserved colours**: the underlay may use any colour from its
+ *    derived (lightened) palette.
+ *
+ * See `docs/SHARED-VISUAL-SPEC.md` §0/§6.
  */
 
 export interface Hsl {
@@ -19,10 +30,50 @@ export interface Hsl {
 /** The Onionskin sticker palette — the fallback base when a template exposes no colour. */
 export const STICKER_PALETTE = ["#D8638C", "#E2825E", "#8FA98A", "#88B0D4", "#A99BC6", "#EBC559"];
 
-// Legibility floors (lightness, 0–1). Text must be dark on cream; banner pills hold
-// white text so they stay mid-dark; accents (markers/rules/numbers) sit in between.
-const TEXT_L_MAX = 0.34;
-const ACCENT_L_MAX = 0.46;
+/**
+ * A named starting point for a chapter's 5 derived ink colours — mirrors the app's
+ * `PaletteCharacter` (`Onionskin/DesignSystem/InkPalette.swift`). THESE NAMES AND
+ * HEXES ARE A DESIGN PROPOSAL (design/INK-PALETTE.md) — confirm with Bridget before
+ * treating as final; kept in sync by hand with the Swift catalogue for now.
+ */
+export const PALETTE_CHARACTERS: Record<string, string[]> = {
+  sunbaked: ["#B0492E", "#C4623F", "#8F6A16", "#A8506A", "#6F4A33"],
+  tidewater: ["#4A6FA5", "#2E7C82", "#4E5F82", "#2F6E57", "#45508C"],
+  fieldNotes: ["#6B761F", "#4F7A4A", "#9A5A32", "#8A6A1E", "#6F4A33"],
+  orchard: ["#7A3F73", "#93304C", "#226E6A", "#2F7A4E", "#6E4A8C"],
+  dusk: ["#A2586A", "#6F5F9E", "#566B93", "#5E7A5C", "#855A78"],
+  highlighter: ["#C2266E", "#1F5FD0", "#12855C", "#C85E18", "#6A34C4"],
+};
+
+/** The default palette character for a chapter with none set — pen-blue family. */
+export const DEFAULT_PALETTE_CHARACTER = "tidewater";
+
+/** A chapter's ink palette resolved to 5 hexes, honouring `paletteCharacter`/month. */
+export function resolvePaletteCharacterInks(id: string | undefined): string[] {
+  return (id && PALETTE_CHARACTERS[id]) || PALETTE_CHARACTERS[DEFAULT_PALETTE_CHARACTER];
+}
+
+/**
+ * Monthly/seasonal ink derivation (mirrors the app's `MonthlyInkHarmony`) — 5 ink
+ * hexes from a seasonal anchor hue + four companions spaced around the wheel.
+ */
+export function monthlyInks(month: number): string[] {
+  const base = seasonalAnchorHue(month);
+  return [0, 55, -55, 130, 190].map((offset) => hslToHex({ h: base + offset, s: 0.45, l: 0.34 }));
+}
+
+/** Northern-hemisphere season anchor hue — matches the app's `MonthlyInkHarmony`. */
+function seasonalAnchorHue(month: number): number {
+  if (month === 12 || month <= 2) return 212; // winter — icy blue
+  if (month <= 5) return 142; // spring — green
+  if (month <= 8) return 32; // summer — coral
+  return 22; // autumn — rust
+}
+
+// Legibility floors (lightness, 0–1) — retained ONLY for banner fills, which sit
+// behind white pill text (a different contrast pair than Rule 1's "text on paper").
+// Body/serif/accent text now go through the real WCAG floor (`floorTextHex`/
+// `floorAccentHex`) instead of these bands.
 const BANNER_L_MIN = 0.4;
 const BANNER_L_MAX = 0.6;
 
@@ -86,14 +137,98 @@ export function hslToHex({ h, s, l }: Hsl): string {
   return `#${to(r)}${to(g)}${to(b)}`;
 }
 
-/** Move a colour's lightness no higher than `max` (keeps it legible), keeping hue/sat. */
-function darkenTo(hsl: Hsl, max: number): Hsl {
-  return { ...hsl, l: Math.min(hsl.l, max) };
-}
-
 /** Pull a colour into a lightness band (for banner pills behind white text). */
 function bandLightness(hsl: Hsl, min: number, max: number): Hsl {
   return { ...hsl, l: Math.max(min, Math.min(max, hsl.l)) };
+}
+
+// MARK: - WCAG contrast (Rule 1) + the pre-lightened underlay (Rule 2)
+
+const PAPER_HSL: Hsl = hexToHslLazy();
+function hexToHslLazy(): Hsl {
+  // `PAPER_COLOR` lives in template.ts; avoided importing it here to keep this module
+  // dependency-free (per its header doc) — the literal is the same constant.
+  return hexToHsl("#FFFEFB");
+}
+
+/** WCAG relative luminance (0 black … 1 white) from HSL via its RGB. */
+function relativeLuminance(hsl: Hsl): number {
+  const hex = hslToHex(hsl);
+  const r = parseInt(hex.slice(1, 3), 16) / 255;
+  const g = parseInt(hex.slice(3, 5), 16) / 255;
+  const b = parseInt(hex.slice(5, 7), 16) / 255;
+  const lin = (c: number) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+/** WCAG contrast ratio between two HSL colours (always ≥ 1). */
+export function contrastRatio(a: Hsl, b: Hsl): number {
+  const l1 = Math.max(relativeLuminance(a), relativeLuminance(b)) + 0.05;
+  const l2 = Math.min(relativeLuminance(a), relativeLuminance(b)) + 0.05;
+  return l1 / l2;
+}
+
+/** WCAG contrast ratio between two hex colours (convenience over `contrastRatio`). */
+export function contrastRatioHex(a: string, b: string): number {
+  return contrastRatio(hexToHsl(a), hexToHsl(b));
+}
+
+/** Rule 1: the contrast floor every underlay TEXT colour must clear against paper-0. */
+export const CONTRAST_FLOOR = 4.5;
+
+/**
+ * Rule 1 — darken (drop HSL lightness, keep hue/sat) until `hsl` clears `CONTRAST_FLOOR`
+ * against paper. A colour already at/above the floor passes through unchanged. This
+ * replaces the old hand-tuned lightness bands (`TEXT_L_MAX`/`ACCENT_L_MAX`) with real
+ * WCAG math — see `docs/ROADMAP.md`'s note that the lightness-band approach was always
+ * a placeholder for this.
+ */
+function floorForContrast(hsl: Hsl): Hsl {
+  let current = hsl;
+  let l = hsl.l;
+  let guardN = 0;
+  while (contrastRatio(current, PAPER_HSL) < CONTRAST_FLOOR && l > 0.02 && guardN < 60) {
+    l = Math.max(0, l - 0.02);
+    current = { ...hsl, l };
+    guardN += 1;
+  }
+  return current;
+}
+
+/**
+ * Rule 2 — lift a colour lighter by `offset` (HSL lightness), but stop early — never
+ * reaching the full offset — if going further would drop contrast against paper below
+ * `CONTRAST_FLOOR`. The floor always wins over the offset: one rule, two guarantees
+ * (the underlay is always lighter than the matching ink colour, and always readable).
+ *
+ * Defensively re-floors the input first (Rule 1) rather than assuming the caller
+ * already guaranteed it: a palette-character hex is a design proposal, not a verified
+ * token, and a couple of proposed inks (Sunbaked's coral, Highlighter's tangerine)
+ * don't themselves clear 4.5:1 on paper — this makes the rule hold regardless.
+ *
+ * `offset` (default 0.14) is a PROPOSED default (design/INK-PALETTE.md) — flag as TBD,
+ * not a final token, when surfacing this to Bridget.
+ */
+export function liftForUnderlay(hex: string, offset = 0.14): string {
+  const floored = floorForContrast(hexToHsl(hex));
+  const targetL = Math.min(1, floored.l + offset);
+  if (targetL <= floored.l) return hslToHex(floored);
+  let current = floored;
+  let l = floored.l;
+  const step = 0.01;
+  while (l < targetL) {
+    const candidateL = Math.min(targetL, l + step);
+    const candidate = { ...floored, l: candidateL };
+    if (contrastRatio(candidate, PAPER_HSL) < CONTRAST_FLOOR) break;
+    current = candidate;
+    l = candidateL;
+  }
+  return hslToHex(current);
+}
+
+/** The underlay palette (5 hexes) lifted from a chapter's resolved ink-character inks. */
+export function liftPaletteForUnderlay(inks: string[], offset = 0.14): string[] {
+  return inks.map((hex) => liftForUnderlay(hex, offset));
 }
 
 export type Harmony = "match" | "complement" | "warm" | "cool" | "seasonal";
@@ -145,7 +280,7 @@ export function derivePalette(
       }
     })
     .filter((x): x is Hsl => x !== null);
-  const seed = src.length ? src : [hexToHsl("#9C7C1A")];
+  const seed = src.length ? src : [hexToHsl(resolvePaletteCharacterInks(undefined)[0])];
   const dominant = seed[0];
 
   // Build the family of accent hues this harmony implies (before lightness shaping).
@@ -184,10 +319,10 @@ export function derivePalette(
     .slice(0, bannerCount)
     .map((c) => hslToHex(bandLightness(c, BANNER_L_MIN, BANNER_L_MAX)));
 
-  const accent = hslToHex(darkenTo(family[0], ACCENT_L_MAX));
-  const text = hslToHex(darkenTo({ ...dominant, s: Math.min(dominant.s, 0.5) }, TEXT_L_MAX));
+  const accent = hslToHex(floorForContrast(family[0]));
+  const text = hslToHex(floorForContrast({ ...dominant, s: Math.min(dominant.s, 0.5) }));
   // The serif (quote) leans a touch warmer/colourful than body ink but still dark.
-  const serif = hslToHex(darkenTo(family[Math.min(1, family.length - 1)], TEXT_L_MAX));
+  const serif = hslToHex(floorForContrast(family[Math.min(1, family.length - 1)]));
   return { text, serif, accent, banners };
 }
 
@@ -200,21 +335,40 @@ export function derivePalette(
  */
 export function deriveAccentPalette(accent: string): DerivedPalette {
   const base = hexToHsl(accent);
-  const text = hslToHex(darkenTo({ ...base, s: Math.min(base.s, 0.55) }, TEXT_L_MAX));
-  const serif = hslToHex(darkenTo(base, TEXT_L_MAX));
-  const acc = hslToHex(darkenTo(base, ACCENT_L_MAX));
+  const text = hslToHex(floorForContrast({ ...base, s: Math.min(base.s, 0.55) }));
+  const serif = hslToHex(floorForContrast(base));
+  const acc = hslToHex(floorForContrast(base));
   const banner = hslToHex(bandLightness(base, BANNER_L_MIN, BANNER_L_MAX));
   return { text, serif, accent: acc, banners: [banner] };
 }
 
-/** Floor a hex for use as body/serif text on cream (the same bound as derivePalette). */
-export function floorTextHex(hex: string): string {
-  return hslToHex(darkenTo(hexToHsl(hex), TEXT_L_MAX));
+/**
+ * The default underlay palette — a chapter's own resolved ink colours (5 hexes: a
+ * palette character's inks, or a month's `monthlyInks`), lifted per Rule 2 instead of
+ * floored dark. This is the palette a chapter with no `harmony`/`accent`/preset
+ * `theme` gets: NOT a fixed seed colour (gold is retired) — the underlay is always
+ * the chapter's own ink identity, just lighter than the hand.
+ */
+export function derivePaletteFromInks(inks: string[]): DerivedPalette {
+  const source = inks.length ? inks : resolvePaletteCharacterInks(undefined);
+  const lifted = source.map((hex) => liftForUnderlay(hex));
+  const text = lifted[0];
+  const serif = lifted[1] ?? lifted[0];
+  const accent = lifted[0];
+  const banners = (lifted.length > 2 ? lifted.slice(2) : lifted).map((hex) =>
+    hslToHex(bandLightness(hexToHsl(hex), BANNER_L_MIN, BANNER_L_MAX)),
+  );
+  return { text, serif, accent, banners };
 }
 
-/** Floor a hex for accents — markers, rules, calendar day numbers — on cream. */
+/** Floor a hex for use as body/serif text on cream — Rule 1's real WCAG contrast floor. */
+export function floorTextHex(hex: string): string {
+  return hslToHex(floorForContrast(hexToHsl(hex)));
+}
+
+/** Floor a hex for accents — markers, rules, calendar day numbers — on cream (Rule 1). */
 export function floorAccentHex(hex: string): string {
-  return hslToHex(darkenTo(hexToHsl(hex), ACCENT_L_MAX));
+  return hslToHex(floorForContrast(hexToHsl(hex)));
 }
 
 /** Nudge a hue toward `target` by `amount` (0–1) along the shorter arc. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const server = new McpServer(
   {
     instructions:
       "Onionskin is a planner whose pages are folders of SVG layers in an iCloud " +
-      "folder. You write the gold 'ai.svg' underlay (schedule, to-dos, focus, and the " +
+      "folder. You write the 'ai.svg' AI underlay (schedule, to-dos, focus, and the " +
       "ainotes AI-voice block) into pages under Shared/, then mark it ready — the app " +
       "composites it on next foreground. Always call get_library first, then read_page " +
       "to learn a page's regions before write_underlay (region names vary by template). " +
@@ -159,9 +159,13 @@ server.tool(
     "`paperColor` (the page's paper/background colour — generate soft-edged art on this to " +
     "place it opaque with no knockout/halo; see docs/AUTHORING.md): if styled, fill quietly " +
     "in those colours; if bare, go full (theme + banners + art). Also returns " +
-    "the chapter's `theme` (harmony/varietyDial/fontPersonality + an explicit `accent` + " +
-    "chromeAccent), which write_underlay applies as the default palette/fonts unless you " +
-    "override it per call. Set it with set_chapter_theme.",
+    "the chapter's `theme` (paletteCharacter/customInk1/customInk2/harmony/varietyDial/" +
+    "fontPersonality + an explicit `accent` + chromeAccent + displayName), which " +
+    "write_underlay applies as the default palette/fonts unless you override it per call " +
+    "(set it with set_chapter_theme), and `underlay` — the RESOLVED palette a default " +
+    "write will use (lifted + contrast-floored hexes: text/serif/accent/banners/" +
+    "headingStyle + the chromeAccent-derived washiTint). Pick per-line `fill`s from " +
+    "`underlay` so your colours stay in the chapter's family.",
   {
     page: z
       .string()
@@ -243,7 +247,7 @@ const FONT_ENUM = z.enum([
 const PHOSPHOR_ICON_NAMES = Object.keys(PHOSPHOR_CODEPOINTS) as [string, ...string[]];
 
 const lineSchema = z.object({
-  text: z.string().describe("The text to draw (gold)."),
+  text: z.string().describe("The text to draw."),
   row: z
     .number()
     .int()
@@ -284,7 +288,9 @@ const lineSchema = z.object({
         "if `time` is not also set.",
     ),
   blockFill: HEX_COLOR.optional().describe(
-    "Override the washi block's tint (hex). Defaults to the theme's accent colour.",
+    "Override the washi block's tint (hex). Defaults to the chapter's chromeAccent " +
+      "(the chapter accent tints duration blocks), else the theme's accent colour. " +
+      "A no-text fill — used raw, never auto-darkened.",
   ),
   blockOpacity: z
     .number()
@@ -306,7 +312,11 @@ const lineSchema = z.object({
     .int()
     .optional()
     .describe("SVG font-weight (100–900). Defaults per region (600; 500 for the serif ainotes)."),
-  fill: HEX_COLOR.optional().describe("Override colour (hex). Defaults to the gold default."),
+  fill: HEX_COLOR.optional().describe(
+    "Override colour (hex). Defaults to the resolved theme colour (gold is retired). " +
+      "Auto-darkened to the ≥4.5:1 contrast floor when drawn as text — pick from " +
+      "read_page's `underlay` palette to stay in the chapter's colours.",
+  ),
   marker: z
     .enum(["checkbox", "bullet"])
     .optional()
@@ -368,7 +378,10 @@ const calendarSchema = z.object({
     .describe("Optional per-day event labels / styling."),
   numberSize: z.number().optional().describe("Day-number font size (default 18)."),
   numberWeight: z.number().int().optional().describe("Day-number weight (default 600)."),
-  fill: HEX_COLOR.optional().describe("Override gold for the day numbers (hex)."),
+  fill: HEX_COLOR.optional().describe(
+    "Override the resolved theme colour for the day numbers (hex). Auto-darkened to " +
+      "the ≥4.5:1 contrast floor (day numbers are text).",
+  ),
 }).strict();
 
 // An AI-owned image placed in a region — the caller supplies the bytes (base64);
@@ -450,7 +463,7 @@ const imageSchema = z.object({
 
 server.tool(
   "write_underlay",
-  "Write a shared page's gold ai.svg (atomically) and set its status. Provide EITHER " +
+  "Write a shared page's ai.svg (atomically) and set its status. Provide EITHER " +
     "`regions` (structured — the server positions each line from the page's geometry; " +
     "preferred) OR `svg` (a full <svg> document you composed yourself). A region may also " +
     "carry `images` (base64/path art the server writes to the page's media/ai/ folder and " +
@@ -780,6 +793,26 @@ server.tool(
           "instead of a fixed seed. Additive alongside the app's `chromeAccent`/`harmony`/" +
           "`varietyDial`/`fontPersonality` keys — never overwrites them.",
       ),
+    customInk1: z
+      .string()
+      .regex(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/, "customInk1 must be a hex colour like #7B5EA7")
+      .optional()
+      .describe(
+        "Extra user ink slot (hex), appended to the palette character's 5-ink pool — the " +
+          "app's tray is 7 (5 derived + 2 custom). Widens the underlay's banner/fill choices.",
+      ),
+    customInk2: z
+      .string()
+      .regex(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/, "customInk2 must be a hex colour like #7B5EA7")
+      .optional()
+      .describe("Second extra user ink slot (hex) — see customInk1."),
+    displayName: z
+      .string()
+      .optional()
+      .describe(
+        'Friendly chapter identity (e.g. "lavender to-dos") — advisory only; surfaced by ' +
+          "read_page, never used to derive colours.",
+      ),
     harmony: z
       .enum(["match", "complement", "warm", "cool", "seasonal"])
       .optional()
@@ -796,12 +829,25 @@ server.tool(
       .describe("AI-text voice: clean / handwritten / editorial."),
   },
   { idempotentHint: true },
-  async ({ chapter, accent, paletteCharacter, harmony, varietyDial, fontPersonality }) => {
+  async ({
+    chapter,
+    accent,
+    paletteCharacter,
+    customInk1,
+    customInk2,
+    displayName,
+    harmony,
+    varietyDial,
+    fontPersonality,
+  }) => {
     try {
       const root = await requireLibrary();
       const res = await writeChapterTheme(root, chapter, {
         accent,
         paletteCharacter,
+        customInk1,
+        customInk2,
+        displayName,
         harmony,
         varietyDial,
         fontPersonality,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ import {
   fetchImageToTemp,
 } from "./page.js";
 import { PHOSPHOR_CODEPOINTS } from "./svg.js";
+import { PALETTE_CHARACTERS } from "./color.js";
+
+const PALETTE_CHARACTER_IDS = Object.keys(PALETTE_CHARACTERS) as [string, ...string[]];
 
 const server = new McpServer(
   {
@@ -563,9 +566,12 @@ server.tool(
         "Named palette PRESET — colours the section banners, body text, and accents. PICK " +
           "IT TO FIT THE DAY: 'bright' (lively, saturated — a fun/light day), 'cozy' (warm, " +
           "hand-painted — a calm or rainy day), 'editorial' (restrained, few accents — a " +
-          "heads-down work day), 'gold' (the quiet monochrome default). For an adaptive " +
-          "palette that harmonises to the template instead, use `harmony`/`varietyDial`. " +
-          "Ignored with raw `svg`.",
+          "heads-down work day), 'gold' (kept for back-compat; gold is RETIRED as a colour — " +
+          "this now resolves to the chapter's own palette character, a calm blue-family " +
+          "default if none is set). For an adaptive palette that harmonises to the template " +
+          "instead, use `harmony`/`varietyDial`; for the chapter's own ink-palette identity, " +
+          "set `paletteCharacter` via `set_chapter_theme` and leave `theme` unset. Ignored " +
+          "with raw `svg`.",
       ),
     harmony: z
       .enum(["match", "complement", "warm", "cool", "seasonal"])
@@ -741,9 +747,12 @@ server.tool(
     "chapter inherits one mood — write_underlay applies it as the default (overridable per " +
     "call) and read_page surfaces it. Use `accent` to give the chapter an explicit colour " +
     "the named presets don't cover (e.g. lavender to-dos): it tints body text, markers, and " +
-    "banners, floored dark to stay legible on cream. `harmony`/`varietyDial`/`fontPersonality` " +
-    "set the adaptive mood. Only the fields you pass are changed; the rest of the theme (and " +
-    "the chapter's page order) is preserved. The chapter must already exist.",
+    "banners, floored dark to stay legible on cream. `paletteCharacter` sets the chapter's " +
+    "ink-tray identity (the app's per-chapter handwriting colours, design/INK-PALETTE.md) — " +
+    "when no `harmony`/`accent`/preset `theme` is given, the underlay derives its default " +
+    "palette from this instead of a fixed colour (gold is retired). `harmony`/`varietyDial`/" +
+    "`fontPersonality` set the adaptive mood. Only the fields you pass are changed; the rest " +
+    "of the theme (and the chapter's page order) is preserved. The chapter must already exist.",
   {
     chapter: z
       .string()
@@ -759,6 +768,17 @@ server.tool(
         "Explicit underlay accent (hex) the whole chapter inherits — tints body text / " +
           "markers / banners. The way to make e.g. to-dos lavender by default; per-day exact " +
           "colour is still available via a line's `fill`.",
+      ),
+    paletteCharacter: z
+      .enum(PALETTE_CHARACTER_IDS)
+      .optional()
+      .describe(
+        "The chapter's ink-tray identity — one of the app's named palette characters " +
+          "(design/INK-PALETTE.md; a design proposal, names may change). When set and no " +
+          "`accent`/`harmony`/preset `theme` overrides it, the underlay's default palette " +
+          "derives from this chapter's own ink colours (lifted lighter, still legible) " +
+          "instead of a fixed seed. Additive alongside the app's `chromeAccent`/`harmony`/" +
+          "`varietyDial`/`fontPersonality` keys — never overwrites them.",
       ),
     harmony: z
       .enum(["match", "complement", "warm", "cool", "seasonal"])
@@ -776,11 +796,12 @@ server.tool(
       .describe("AI-text voice: clean / handwritten / editorial."),
   },
   { idempotentHint: true },
-  async ({ chapter, accent, harmony, varietyDial, fontPersonality }) => {
+  async ({ chapter, accent, paletteCharacter, harmony, varietyDial, fontPersonality }) => {
     try {
       const root = await requireLibrary();
       const res = await writeChapterTheme(root, chapter, {
         accent,
+        paletteCharacter,
         harmony,
         varietyDial,
         fontPersonality,

--- a/src/library.ts
+++ b/src/library.ts
@@ -5,7 +5,7 @@ import { type AiStatus, type Manifest, readIfExists } from "./page.js";
 
 /**
  * The library's `settings.json → underlayVoice` (the app's `FORMAT.md §4` contract) —
- * personalizes the gold daily note. All keys optional; `tone: "none"` means no written
+ * personalizes the AI daily note. All keys optional; `tone: "none"` means no written
  * note at all. Read-only here — the server never writes settings.json.
  */
 export interface UnderlayVoice {

--- a/src/page.ts
+++ b/src/page.ts
@@ -16,6 +16,7 @@ import { readUnderlayVoice, type UnderlayVoice } from "./library.js";
 import {
   composeAiSvg,
   mergeRegions,
+  resolveTheme,
   emptySvg,
   imageDims,
   scanRawSvgElements,
@@ -55,6 +56,14 @@ export interface ChapterTheme {
    * palette source (lifted lighter, still legible) instead of a fixed seed colour.
    */
   paletteCharacter?: string;
+  /**
+   * Extra user ink slots (hex) appended to the character's 5-ink pool — the app's
+   * tray is 7 (5 derived + 2 custom). Additive `FORMAT.md §4` keys, read defensively.
+   */
+  customInk1?: string;
+  customInk2?: string;
+  /** Friendly chapter identity (e.g. "lavender to-dos") — advisory, surfaced only. */
+  displayName?: string;
 }
 
 /**
@@ -134,16 +143,25 @@ async function resolveThemeInput(
       fontPersonality: chapter?.fontPersonality,
       accent: chapter?.accent,
       paletteCharacter: chapter?.paletteCharacter,
+      customInk1: chapter?.customInk1,
+      customInk2: chapter?.customInk2,
+      chromeAccent: chapter?.chromeAccent,
       templatePalette,
     };
   }
+  // A chapter's `paletteCharacter` IS its colour identity, so it beats the chapter's
+  // own `harmony`/`varietyDial` (which derive from the template's colours instead) —
+  // but a *per-call* adaptive param is an explicit override and always forwards.
+  const chapterAdaptive = chapter?.paletteCharacter ? undefined : chapter;
   return {
     name: opts.theme,
-    harmony: opts.harmony ?? chapter?.harmony,
-    varietyDial: opts.varietyDial ?? chapter?.varietyDial,
+    harmony: opts.harmony ?? chapterAdaptive?.harmony,
+    varietyDial: opts.varietyDial ?? chapterAdaptive?.varietyDial,
     fontPersonality: opts.fontPersonality ?? chapter?.fontPersonality,
     accent: chapter?.accent,
     paletteCharacter: chapter?.paletteCharacter,
+    customInk1: chapter?.customInk1,
+    customInk2: chapter?.customInk2,
     chromeAccent: chapter?.chromeAccent,
     templatePalette,
   };
@@ -631,6 +649,21 @@ export interface PageRead {
    */
   theme: ChapterTheme | null;
   /**
+   * The **resolved** underlay palette a default (no per-call override) write will
+   * use — the chapter's theme run through the same `resolveThemeInput → resolveTheme`
+   * path `write_underlay` takes, so what's advertised here and what gets composed can
+   * never drift. Hexes are already lifted + contrast-floored; an orchestrator picking
+   * per-line `fill`s should pick from these.
+   */
+  underlay: {
+    text: string;
+    serif: string;
+    accent: string;
+    banners: string[];
+    headingStyle: "banner" | "underline";
+    washiTint?: string;
+  };
+  /**
    * The library's `settings.json → underlayVoice` (name/tone/notes), or null if
    * absent/garbled — personalizes the `ainotes` note's voice. Read-only; the server
    * never writes settings.json.
@@ -653,6 +686,16 @@ export async function readPage(
   const regions = templateSvg ? parseRegions(templateSvg, manifest.template) : [];
   const size = pageSize(manifest, templateSvg);
   const theme = await readChapterTheme(abs);
+  // The default-write palette, via the exact path write_underlay resolves with.
+  const resolved = resolveTheme(await resolveThemeInput(abs, templateSvg, {})).theme;
+  const underlay = {
+    text: resolved.text,
+    serif: resolved.serif,
+    accent: resolved.accent,
+    banners: resolved.banners,
+    headingStyle: resolved.headingStyle,
+    ...(resolved.washiTint ? { washiTint: resolved.washiTint } : {}),
+  };
   const underlayVoice = await readUnderlayVoice(root);
   // labelFilled: cross-reference each region's labelSlot geometry (template-only)
   // against what the current ai.svg actually drew for that region — geometry alone
@@ -680,6 +723,7 @@ export async function readPage(
           paperColor: PAPER_COLOR,
         },
     theme,
+    underlay,
     underlayVoice,
     ...(includeTemplate && templateSvg ? { templateSvg } : {}),
   };

--- a/src/page.ts
+++ b/src/page.ts
@@ -31,8 +31,9 @@ import { decodePng, encodePng, chromaKeyPixels } from "./png.js";
 /**
  * The underlay-relevant slice of a chapter's `.folder.json → theme` (the app's
  * `FORMAT.md §4` contract). `chromeAccent` is the app's concern (chrome only); the
- * other three are the underlay-theme axis this server honours. All optional — an
- * absent block (or key) just means "fall back to the default" (gold / region fonts).
+ * rest are the underlay-theme axis this server honours. All optional — an absent
+ * block (or key) just means "fall back to the default" (the chapter's own resolved
+ * ink palette, lifted for the underlay — gold is retired, there's no fixed seed).
  */
 export interface ChapterTheme {
   chromeAccent?: string;
@@ -43,9 +44,17 @@ export interface ChapterTheme {
    * An explicit underlay accent (hex) the whole chapter inherits — tints body text /
    * markers / banners so a chapter can carry a colour the named presets don't (e.g.
    * lavender). Additive to the app's `FORMAT.md §4` theme keys; the server reads it
-   * defensively (absent ⇒ the gold/preset default). Written by `set_chapter_theme`.
+   * defensively (absent ⇒ the palette-character/preset default). Written by
+   * `set_chapter_theme`. Takes precedence over `paletteCharacter` when both are set.
    */
   accent?: string;
+  /**
+   * The chapter's ink-tray identity (design/INK-PALETTE.md) — one of
+   * `PALETTE_CHARACTERS`' keys, additive alongside the app's own theme keys. When no
+   * `accent`/`harmony`/preset `theme` overrides it, this is the default underlay
+   * palette source (lifted lighter, still legible) instead of a fixed seed colour.
+   */
+  paletteCharacter?: string;
 }
 
 /**
@@ -124,6 +133,7 @@ async function resolveThemeInput(
       name: opts.theme,
       fontPersonality: chapter?.fontPersonality,
       accent: chapter?.accent,
+      paletteCharacter: chapter?.paletteCharacter,
       templatePalette,
     };
   }
@@ -133,6 +143,7 @@ async function resolveThemeInput(
     varietyDial: opts.varietyDial ?? chapter?.varietyDial,
     fontPersonality: opts.fontPersonality ?? chapter?.fontPersonality,
     accent: chapter?.accent,
+    paletteCharacter: chapter?.paletteCharacter,
     chromeAccent: chapter?.chromeAccent,
     templatePalette,
   };

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -2,19 +2,19 @@ import type { Region } from "./template.js";
 import {
   derivePalette,
   deriveAccentPalette,
+  derivePaletteFromInks,
+  resolvePaletteCharacterInks,
   floorTextHex,
   floorAccentHex,
   type Harmony,
 } from "./color.js";
 
 /**
- * The single canonical Onionskin gold, per the contract — one value shared by the
- * app chrome, this MCP, and the on-device composer (deepened so it stays legible on
- * the cream page). One constant — retune here if the brand gold shifts. (`#7E5C12`,
- * the chrome's AA-tuned *text* gold, is deliberately NOT used in the underlay — the
- * locked contract emits one gold here; see `docs/SHARED-VISUAL-SPEC.md` §0.)
+ * Gold is retired (design decisions, 2026-07-09) — there is no fixed seed colour any
+ * more. The default underlay palette derives from the chapter's own resolved ink
+ * palette (`derivePaletteFromInks` — a palette character's inks, or a month's
+ * `monthlyInks`), lifted lighter per Rule 2; see `docs/SHARED-VISUAL-SPEC.md` §0/§6.
  */
-export const GOLD = "#9C7C1A";
 
 /**
  * The SVG elements the app's custom renderer handles (SwiftUI `Canvas` + `XMLParser`,
@@ -67,10 +67,10 @@ export interface ThemeFonts {
 }
 
 /**
- * A resolved page palette + fonts. Gold was only ever a *default*, not a constraint —
- * the app renderer honours any `fill`, so the AI layer can carry colour. A theme maps
- * the composer's colour roles; callers pick a named preset *or* the adaptive param
- * block (`harmony`/`varietyDial`/`fontPersonality`) via `write_underlay`.
+ * A resolved page palette + fonts — the app renderer honours any `fill`, so the AI
+ * layer can carry colour. A theme maps the composer's colour roles; callers pick a
+ * named preset, a chapter's `paletteCharacter`, an explicit `accent`, *or* the
+ * adaptive param block (`harmony`/`varietyDial`/`fontPersonality`) via `write_underlay`.
  *
  * - `text`/`serif`: body text (serif = the `ainotes` AI-voice region).
  * - `accent`: markers (checkbox/bullet), rules, calendar day numbers.
@@ -92,9 +92,8 @@ export interface Theme {
 
 /**
  * Floor a preset's text/serif/accent to the same cream-legibility bounds the adaptive
- * palette derives under (the contract's AA rule applies to every path, not just the
- * derived one). Banners are untouched — they sit behind white pill text, a different
- * bound. The gold preset skips this: gold is the one canonical value, tuned by hand.
+ * palette derives under (Rule 1 applies to every path, not just the derived one).
+ * Banners are untouched — they sit behind white pill text, a different bound.
  */
 function legible(t: Theme): Theme {
   return {
@@ -105,12 +104,24 @@ function legible(t: Theme): Theme {
   };
 }
 
+/**
+ * The default theme — the chapter's own resolved ink palette (or, absent one, the
+ * default palette character), lifted for the underlay. Kept as a named "gold" preset
+ * ONLY for back-compat with existing `theme:"gold"` calls; it no longer emits a fixed
+ * colour (gold is retired) — resolving it dynamically means a bare `theme:"gold"` call
+ * still honours whatever palette character the chapter has set.
+ */
+function defaultTheme(inks?: string[]): Theme {
+  const p = derivePaletteFromInks(inks ?? resolvePaletteCharacterInks(undefined));
+  return {
+    text: p.text, serif: p.serif, accent: p.accent,
+    bannerText: "#FFFFFF", banners: p.banners, headingStyle: "underline",
+  };
+}
+
 export const THEMES: Record<string, Theme> = {
-  // The legacy monochrome default — unchanged output when no theme is chosen.
-  gold: {
-    text: GOLD, serif: GOLD, accent: GOLD,
-    bannerText: "#FFFFFF", banners: [GOLD], headingStyle: "underline",
-  },
+  // Back-compat name only — no longer a fixed colour. See `defaultTheme`.
+  gold: defaultTheme(),
   // Lively, saturated — closest to a colourful planner spread.
   bright: legible({
     text: "#3A3A3A", serif: "#8E6FC9", accent: "#E86A92",
@@ -120,7 +131,7 @@ export const THEMES: Record<string, Theme> = {
   // Softer, hand-painted warmth.
   cozy: legible({
     text: "#4A4A4A", serif: "#7E5A78", accent: "#C56B6B",
-    bannerText: "#FFFFFF", banners: ["#C56B6B", "#7C8A5A", "#9C7C1A", "#7E5A78"],
+    bannerText: "#FFFFFF", banners: ["#C56B6B", "#7C8A5A", "#8F6A16", "#7E5A78"],
     headingStyle: "banner",
   }),
   // Restrained — one or two accents, quiet labels, lots of whitespace.
@@ -170,6 +181,13 @@ export interface ThemeInput {
    * given (harmony/preset win); floored dark for cream via `deriveAccentPalette`.
    */
   accent?: string;
+  /**
+   * The chapter's ink-tray identity (design/INK-PALETTE.md) — one of
+   * `PALETTE_CHARACTERS`' keys. The default underlay palette source when no
+   * `harmony`/`accent`/preset `name` is given: gold is retired, so an otherwise-bare
+   * page derives from the chapter's own ink colours (lifted lighter) instead.
+   */
+  paletteCharacter?: string;
   /** App-only chrome accent; accepted for contract-completeness, not used here. */
   chromeAccent?: string;
   /** Current month (1–12) for `seasonal` harmony; defaults to the real month. */
@@ -180,7 +198,7 @@ export interface ThemeInput {
  * True when the input asks for an adaptive (harmony-derived) *colour* palette. Only
  * the colour knobs (`harmony`/`varietyDial`) trigger this — `fontPersonality` is a
  * font axis (layered on any palette below) and the always-sampled `templatePalette`
- * is mere context, so neither one alone flips a default-gold page into a derived one.
+ * is mere context, so neither one alone flips a default page into a derived one.
  */
 function isAdaptive(t: ThemeInput): boolean {
   return t.harmony !== undefined || t.varietyDial !== undefined;
@@ -195,9 +213,11 @@ export interface ResolvedTheme {
 /**
  * Resolve a theme. Precedence: an **adaptive** param block (`harmony` and/or
  * `varietyDial` — see `isAdaptive`) derives a palette from the template's colours;
- * otherwise a named **preset**; otherwise a chapter `accent`; otherwise the gold
- * default. `fontPersonality` always layers its fonts on top of whichever palette
- * path is taken (it never selects one). A string is a bare preset name (back-compat).
+ * otherwise a named **preset**; otherwise a chapter `accent`; otherwise the chapter's
+ * own `paletteCharacter`; otherwise the default palette character (gold is retired —
+ * there is no fixed seed colour at the end of this chain any more).
+ * `fontPersonality` always layers its fonts on top of whichever palette path is taken
+ * (it never selects one). A string is a bare preset name (back-compat).
  */
 export function resolveTheme(input?: ThemeInput | string): ResolvedTheme {
   const t: ThemeInput = typeof input === "string" ? { name: input } : input ?? {};
@@ -240,11 +260,13 @@ export function resolveTheme(input?: ThemeInput | string): ResolvedTheme {
         headingStyle: "underline",
       };
     } catch {
-      warnings.push(`theme: accent "${t.accent}" is not a hex colour — used the gold default.`);
-      theme = THEMES.gold;
+      warnings.push(`theme: accent "${t.accent}" is not a hex colour — used the default palette.`);
+      theme = defaultTheme();
     }
   } else {
-    theme = THEMES.gold;
+    // No override at all — the chapter's own ink-tray identity (or the default
+    // palette character if unset), lifted for the underlay.
+    theme = defaultTheme(t.paletteCharacter ? resolvePaletteCharacterInks(t.paletteCharacter) : undefined);
   }
 
   if (t.fontPersonality) {
@@ -264,7 +286,7 @@ function themeFontFor(theme: Theme, regionName: string, heading: boolean): strin
 }
 
 const DEFAULT_X_PAD = 24;
-/** Default text weight — heavier than regular to carry the gold on white. */
+/** Default text weight — heavier than regular to carry the theme colour on white. */
 const DEFAULT_WEIGHT = 600;
 
 /**
@@ -388,7 +410,7 @@ export interface LineInput {
   wrap?: boolean;
   /**
    * Render this line as a section heading rather than body text: bold, letter-
-   * spaced, with a hairline gold rule beneath it spanning the region width. This
+   * spaced, with a hairline themed rule beneath it spanning the region width. This
    * is how the AI layer draws *dynamic structure* into a neutral region — e.g.
    * carving the `notes` box into "Important" / "Tomorrow" / "Habits" sub-blocks
    * only on the days that need them, so the printed template can stay minimal.
@@ -416,7 +438,7 @@ export interface CalendarSpec {
   month: string;
   /** Optional per-day event labels / styling. */
   days?: CalendarDay[];
-  /** Day-number styling (defaults: Mulish 18 / weight 600 / gold). */
+  /** Day-number styling (defaults: Mulish 18 / weight 600 / theme accent). */
   numberFont?: string;
   numberSize?: number;
   numberWeight?: number;
@@ -485,7 +507,7 @@ export interface RegionInput {
    * A region *title* banner, drawn in the margin just above the region box (so it
    * never consumes a content row). This is how the AI labels a region the template
    * left bare — e.g. "SCHEDULE" / "TOP 3" over a minimal grid. `banner` themes draw
-   * a colored pill; `underline`/`gold` themes a bold label + short rule. (For
+   * a colored pill; `underline`-style themes a bold label + short rule. (For
    * sub-sections *inside* a box, use a `heading` line instead.)
    */
   label?: string;
@@ -974,7 +996,7 @@ function gridBounds(
 /**
  * Lay a month's day cells onto a gridded region. Per day: a `<rect
  * data-date="YYYY-MM-DD" fill="none">` covering the cell (the app's tap-to-day
- * target) + a gold day number, plus an optional event label. Returns SVG fragments
+ * target) + a themed day number, plus an optional event label. Returns SVG fragments
  * in LOCAL coordinates (the caller wraps them in the region's translate group, so
  * we subtract the region origin from the absolute grid boundaries).
  */

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -4,6 +4,7 @@ import {
   deriveAccentPalette,
   derivePaletteFromInks,
   resolvePaletteCharacterInks,
+  PALETTE_CHARACTERS,
   floorTextHex,
   floorAccentHex,
   type Harmony,
@@ -88,6 +89,12 @@ export interface Theme {
   banners: string[];
   headingStyle: "banner" | "underline";
   fonts?: ThemeFonts;
+  /**
+   * The chapter's `chromeAccent`, when set — the default tint for washi duration
+   * blocks (a fill that carries no text, so it stays the raw chapter hex; the
+   * translucent tape is the page's strongest echo of the chapter's accent colour).
+   */
+  washiTint?: string;
 }
 
 /**
@@ -188,7 +195,13 @@ export interface ThemeInput {
    * page derives from the chapter's own ink colours (lifted lighter) instead.
    */
   paletteCharacter?: string;
-  /** App-only chrome accent; accepted for contract-completeness, not used here. */
+  /** Extra user ink slots (hex) appended to the character's 5-ink pool (app tray = 7). */
+  customInk1?: string;
+  customInk2?: string;
+  /**
+   * The chapter's accent (also the app's live/refreshing signal colour) — becomes
+   * `Theme.washiTint`, the default duration-block tint, on every resolution path.
+   */
   chromeAccent?: string;
   /** Current month (1–12) for `seasonal` harmony; defaults to the real month. */
   month?: number;
@@ -265,14 +278,48 @@ export function resolveTheme(input?: ThemeInput | string): ResolvedTheme {
     }
   } else {
     // No override at all — the chapter's own ink-tray identity (or the default
-    // palette character if unset), lifted for the underlay.
-    theme = defaultTheme(t.paletteCharacter ? resolvePaletteCharacterInks(t.paletteCharacter) : undefined);
+    // palette character if unset), lifted for the underlay. Custom ink slots append
+    // to the pool (the app's tray = 5 derived + 2 custom), they never replace slots.
+    if (t.paletteCharacter && !PALETTE_CHARACTERS[t.paletteCharacter]) {
+      warnings.push(
+        `theme: unknown paletteCharacter "${t.paletteCharacter}" — used the default ` +
+          `character (known: ${Object.keys(PALETTE_CHARACTERS).join(", ")}).`,
+      );
+    }
+    const inks = [...resolvePaletteCharacterInks(t.paletteCharacter)];
+    for (const custom of [t.customInk1, t.customInk2]) {
+      if (custom === undefined) continue;
+      if (isHexColour(custom)) inks.push(custom);
+      else warnings.push(`theme: custom ink "${custom}" is not a hex colour — ignored.`);
+    }
+    theme = defaultTheme(inks);
   }
 
+  if (t.chromeAccent !== undefined) {
+    // The washi tint is a no-text fill, so the chapter accent rides through raw
+    // (Rule 1's auto-darkening is for text); it layers on every palette path.
+    if (isHexColour(t.chromeAccent)) theme = { ...theme, washiTint: t.chromeAccent };
+    else warnings.push(`theme: chromeAccent "${t.chromeAccent}" is not a hex colour — ignored.`);
+  }
   if (t.fontPersonality) {
     theme = { ...theme, fonts: FONT_PERSONALITIES[t.fontPersonality] };
   }
   return { theme, warnings };
+}
+
+/** Loose hex check (`#rgb`/`#rrggbb`) — mirrors `hexToHsl`'s accepted forms. */
+function isHexColour(s: string): boolean {
+  return /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(s.trim());
+}
+
+/**
+ * Rule 1 applied to a caller-supplied colour that will be drawn as TEXT: auto-darken
+ * to the contrast floor. Only text fills go through this — a raw hex stays raw on
+ * fills that carry no text (washi tint, banner pills, markers/icons). A non-hex
+ * value passes through untouched (same as before — the renderer decides).
+ */
+function floorTextFill(c: string): string {
+  return isHexColour(c) ? floorTextHex(c) : c;
 }
 
 /** Font family for a region's lines, honouring a `fontPersonality` override if set. */
@@ -730,8 +777,10 @@ function iconFragment(
   };
 }
 
-const WASHI_RX = 6; // reuses the one corner-radius convention (SHARED-VISUAL-SPEC §5)
-const WASHI_DEFAULT_OPACITY = 0.22;
+// Washi-block look per the 2026-07-09 decisions (spec owner: the app repo's
+// design/UNDERLAY-VISUAL.md, forthcoming — onionskin#23): ~8px radius, ~0.16 tint.
+const WASHI_RX = 8;
+const WASHI_DEFAULT_OPACITY = 0.16;
 
 /**
  * A washi-tape-style duration block: a rounded, translucent-tint rect spanning
@@ -1034,7 +1083,8 @@ function composeCalendar(
   const numFont = spec.numberFont ?? "Mulish";
   const numSize = spec.numberSize ?? 18;
   const numWeight = spec.numberWeight ?? 600;
-  const fill = spec.fill ?? theme.accent;
+  // Calendar day numbers are text → the override is floored (Rule 1).
+  const fill = spec.fill !== undefined ? floorTextFill(spec.fill) : theme.accent;
   const byDay = new Map((spec.days ?? []).map((d) => [d.day, d]));
 
   const parts: string[] = [];
@@ -1209,7 +1259,7 @@ export function composeAiSvg(
             `font-weight="800" letter-spacing="0.1em" fill="${theme.bannerText}">${escapeXml(input.label)}</text>`,
         );
       } else {
-        const lfill = input.labelFill ?? theme.text;
+        const lfill = input.labelFill !== undefined ? floorTextFill(input.labelFill) : theme.text;
         parts.push(
           `    <text x="${lx}" y="${ly}" font-family="${escapeXml(labelFont)}" font-size="${lsize}" ` +
             `font-weight="800" letter-spacing="0.1em" fill="${lfill}">${escapeXml(input.label)}</text>`,
@@ -1420,7 +1470,7 @@ export function composeAiSvg(
         const size = line.size ?? def.size;
         const font = line.font ?? themeFontFor(theme, region.name, !!line.heading) ?? def.font;
         const weight = line.weight ?? def.weight;
-        const fill = line.fill ?? baseFill;
+        const fill = line.fill !== undefined ? floorTextFill(line.fill) : baseFill;
         let x = line.x ?? def.xPad ?? DEFAULT_X_PAD;
 
         // A washi-tape duration block: `time` + (`endTime`/`durationMin`) draws a
@@ -1469,18 +1519,33 @@ export function composeAiSvg(
             r1 = Math.min(Math.max(0, r1), maxIdx);
             r2 = Math.min(Math.max(0, r2), maxIdx);
           }
-          if (r2 <= r1) {
-            // Too short to span rows on this grid (e.g. a 20-min meeting on a
-            // 1-row-per-hour grid: both ends snap to the same row). The event must
-            // still appear — fall through to the normal time-anchored text line.
+          if (r2 <= r1 && r1 >= maxIdx) {
+            // The one geometry no block fits: the event starts on the grid's last
+            // ruled line, so there is no next line to span to. The event must still
+            // appear — fall through to the normal time-anchored text line.
             warn(
               "washi_block_zero_duration",
               `region "${region.name}": block "${truncate(line.text)}" (${line.time}–${endTimeStr}) ` +
-                `is too short to span rows on this grid — drawn as a plain time line instead.`,
+                `starts on the grid's last ruled line — drawn as a plain time line instead.`,
               "info",
               region.name,
             );
           } else {
+            if (r2 <= r1) {
+              // Min block height is one schedule-line interval, read from the template's
+              // ruled lines (2026-07-09 decisions; spec: design/UNDERLAY-VISUAL.md,
+              // forthcoming) — a 20-min meeting on a 1-row-per-hour grid still draws a
+              // visible tape, not a bare text line. Supersedes the old sub-hour
+              // plain-line fallback (#17).
+              r2 = r1 + 1;
+              warn(
+                "washi_block_min_height",
+                `region "${region.name}": block "${truncate(line.text)}" (${line.time}–${endTimeStr}) ` +
+                  `is shorter than one schedule-line interval — drawn at the one-interval minimum.`,
+                "info",
+                region.name,
+              );
+            }
             const y1 = Math.round(region.ruledLines[r1] - region.y);
             const y2 = Math.round(region.ruledLines[r2] - region.y);
             const bx = line.x ?? def.xPad ?? DEFAULT_X_PAD;
@@ -1498,7 +1563,7 @@ export function composeAiSvg(
               size,
               weight,
               fill,
-              line.blockFill ?? theme.accent,
+              line.blockFill ?? theme.washiTint ?? theme.accent,
               line.blockOpacity ?? WASHI_DEFAULT_OPACITY,
             );
             parts.push(`    ${block.svg}`);
@@ -1596,7 +1661,7 @@ export function composeAiSvg(
                 `fill="${theme.bannerText}">${escapeXml(line.text)}</text>`,
             );
           } else {
-            const hfill = line.fill ?? theme.text;
+            const hfill = line.fill !== undefined ? floorTextFill(line.fill) : theme.text;
             parts.push(
               `    <text x="${x}" y="${y}" font-family="${escapeXml(font)}" ` +
                 `font-size="${size}" font-weight="${hWeight}" letter-spacing="0.08em" ` +

--- a/src/template.ts
+++ b/src/template.ts
@@ -101,7 +101,8 @@ export interface TemplateInfo {
   stickersPresent: boolean;
   /**
    * Non-neutral colours the template itself uses (hex, most-saturated first) — the
-   * palette to MATCH when filling a styled template, instead of defaulting to gold.
+   * palette to MATCH when filling a styled template, instead of defaulting to the
+   * chapter's own ink palette.
    */
   palette: string[];
   /**
@@ -136,10 +137,11 @@ function isNeutral(hex: string): boolean {
 
 /**
  * The app's shared canvas-paper colour, drawn beneath every page (design-system
- * `--paper-0` / Swift `Palette.swift paper0`) — a fixed cross-repo constant, same
- * role as `GOLD` in `svg.ts`. `paperColorOf`'s fallback when a template draws no
- * background of its own, which (as of the 2026-06 redesign catalogue) is every
- * shipped template — the app paints its own canvas surface instead.
+ * `--paper-0` / Swift `Palette.swift paper0`) — a fixed cross-repo constant, and the
+ * background every underlay-palette contrast check (`contrastRatio` in `color.ts`) is
+ * computed against. `paperColorOf`'s fallback when a template draws no background of
+ * its own, which (as of the 2026-06 redesign catalogue) is every shipped template —
+ * the app paints its own canvas surface instead.
  */
 export const PAPER_COLOR = "#FFFEFB";
 

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -31,10 +31,15 @@ import {
   writeChapterTheme,
   fetchImageToTemp,
 } from "../src/page.js";
-import { GOLD, resolveTheme, composeAiSvg, PHOSPHOR_CODEPOINTS, scanRawSvgDataUriImages } from "../src/svg.js";
-import { hexToHsl } from "../src/color.js";
+import { resolveTheme, composeAiSvg, PHOSPHOR_CODEPOINTS, scanRawSvgDataUriImages } from "../src/svg.js";
+import { hexToHsl, contrastRatioHex } from "../src/color.js";
 import { inspectTemplate, parseRegions, PAPER_COLOR } from "../src/template.js";
 import { decodePng, encodePng, chromaKeyPixels } from "../src/png.js";
+
+// Gold is retired — the default (no theme override) resolves to the chapter's own ink
+// palette instead of a fixed seed colour. Tests below assert against THIS, not a literal
+// hex, since the exact default may change as the palette-character proposal is refined.
+const DEFAULT_INK = resolveTheme({}).theme.text;
 
 let pass = 0;
 let fail = 0;
@@ -233,15 +238,15 @@ async function main() {
   const aiPath = path.join(root, daily, "ai.svg");
   const ai = await fs.readFile(aiPath, "utf8");
   check("ai.svg contains schedule text", ai.includes("9:00 standup"));
-  check("ai.svg uses gold fill", ai.includes(GOLD));
+  check("ai.svg uses the default ink-palette fill (gold is retired)", ai.includes(DEFAULT_INK));
   check("ai.svg sets a heavier font-weight", ai.includes('font-weight="600"'));
   check("ai.svg groups by region", ai.includes('data-region="schedule"') && ai.includes('data-region="todo"'));
   check("ainotes uses Newsreader (region default still applies)", regionGroup(ai, "ainotes")?.includes("Newsreader") ?? false);
   check("write reported warnings array", Array.isArray(wr.warnings));
   check("write was not a dry run", wr.dryRun === false);
-  // checkbox marker: a gold stroked <rect> inside the todo group, before its text.
+  // checkbox marker: a themed stroked <rect> inside the todo group, before its text.
   const todoGroup = regionGroup(ai, "todo") ?? "";
-  check("to-do lines draw a gold checkbox", new RegExp(`<rect[^>]*stroke="${GOLD}"`).test(todoGroup), todoGroup.slice(0, 120));
+  check("to-do lines draw a themed checkbox", new RegExp(`<rect[^>]*stroke="${DEFAULT_INK}"`).test(todoGroup), todoGroup.slice(0, 120));
 
   console.log("\nPhosphor icon glyphs (font-rendered leading mark; dry-run)");
   const iconWrite = await writeUnderlay(root, daily, {
@@ -486,7 +491,7 @@ async function main() {
   });
   const notesGroup = regionGroup(sectioned.aiSvg, "todo") ?? "";
   check("heading text is letter-spaced", notesGroup.includes('letter-spacing="0.08em"'), notesGroup.slice(0, 160));
-  const headingRules = [...notesGroup.matchAll(new RegExp(`<line[^>]*stroke="${GOLD}"[^>]*opacity="0.4"`, "g"))].length;
+  const headingRules = [...notesGroup.matchAll(new RegExp(`<line[^>]*stroke="${DEFAULT_INK}"[^>]*opacity="0.4"`, "g"))].length;
   check("each of the 3 headings draws a hairline rule", headingRules === 3, `rules=${headingRules}`);
   // Flow order: headings and their items stack top-down in the order given.
   const yImp = yOf(sectioned.aiSvg, ">Important</text>");
@@ -510,31 +515,43 @@ async function main() {
   const tg = regionGroup(themed.aiSvg, "todo") ?? "";
   check("banner heading draws a filled colored rect", /<rect[^>]*fill="#3FB6A8"/.test(tg) || /<rect[^>]*fill="#F2884B"/.test(tg), tg.slice(0, 200));
   check("two banners use two different cycled colors", new Set([...tg.matchAll(/<rect[^>]*rx="6" fill="(#[0-9A-Fa-f]{6})"/g)].map((m) => m[1])).size === 2, tg);
-  check("banner label is white, not gold", tg.includes('fill="#FFFFFF"') && !tg.includes(GOLD), tg.slice(0, 240));
+  check("banner label is white, not the default ink colour", tg.includes('fill="#FFFFFF"') && !tg.includes(DEFAULT_INK), tg.slice(0, 240));
   // (case-insensitive: the AA floor round-trips the hex through HSL → lowercase)
-  check("themed body text uses theme ink, not gold", /fill="#3a3a3a"/i.test(tg), tg);
-  // The gold default is unchanged (back-compat): headings stay underline+rule.
-  const goldHead = regionGroup((await writeUnderlay(root, daily, { status: "ready", dryRun: true, regions: [{ region: "todo", lines: [{ text: "Plain", heading: true }] }] })).aiSvg, "todo") ?? "";
-  check("default (no theme) keeps the gold underline heading", goldHead.includes(`stroke="${GOLD}"`) && !/<rect[^>]*rx="6"/.test(goldHead), goldHead);
+  check("themed body text uses theme ink, not the default palette", /fill="#3a3a3a"/i.test(tg), tg);
+  // The default (no theme override) is unchanged in SHAPE (back-compat): headings stay
+  // underline+rule — gold is retired, so the COLOUR is now the chapter's own ink palette.
+  const defaultHead = regionGroup((await writeUnderlay(root, daily, { status: "ready", dryRun: true, regions: [{ region: "todo", lines: [{ text: "Plain", heading: true }] }] })).aiSvg, "todo") ?? "";
+  check("default (no theme) keeps the underline heading", defaultHead.includes(`stroke="${DEFAULT_INK}"`) && !/<rect[^>]*rx="6"/.test(defaultHead), defaultHead);
 
   console.log("\nadaptive theme contract (harmony / variety / fontPersonality)");
-  // No knobs → the gold default (back-compat for the resolver itself).
-  check("resolveTheme({}) is the gold default", resolveTheme({}).theme.text === GOLD);
+  // No knobs → the default ink-palette theme (back-compat for the resolver itself; gold retired).
+  check("resolveTheme({}) is the default ink-palette theme", resolveTheme({}).theme.text === DEFAULT_INK);
+  check("the default ink colour clears the ≥4.5:1 contrast floor on paper (Rule 1)", contrastRatioHex(DEFAULT_INK, PAPER_COLOR) >= 4.5);
   // harmony=match derives banners FROM the template palette, not a fixed preset.
   const pal = ["#E2825E", "#8FA98A", "#88B0D4"];
   const matched = resolveTheme({ harmony: "match", varietyDial: 0.9, templatePalette: pal });
   check("harmony=match derives multiple banners from the template palette", matched.theme.banners.length >= 2 && matched.theme.banners.every((h) => /^#[0-9a-f]{6}$/.test(h)), JSON.stringify(matched.theme.banners));
   check("high variety → banner-pill headings", matched.theme.headingStyle === "banner");
   check("low variety → quiet underline headings", resolveTheme({ harmony: "match", varietyDial: 0.1, templatePalette: pal }).theme.headingStyle === "underline");
-  // Legibility floor: derived BODY text is dark enough to read on cream (solved at
-  // derivation, not warned at runtime — even from a pale template swatch).
+  // Rule 1 (real WCAG contrast, not a flat lightness cap): derived BODY text clears
+  // ≥4.5:1 on cream (solved at derivation, not warned at runtime) — even from a pale
+  // template swatch. A hue-aware contrast floor can leave some hues lighter than the
+  // old flat lightness cap while still reading fine — contrast, not raw L, is the rule.
   const pale = resolveTheme({ harmony: "match", templatePalette: ["#F2B8CC"] });
-  check("derived body text is floored dark (legible on cream)", hexToHsl(pale.theme.text).l <= 0.36, `${pale.theme.text} (L=${hexToHsl(pale.theme.text).l.toFixed(2)})`);
+  check("derived body text clears the contrast floor (legible on cream)",
+    contrastRatioHex(pale.theme.text, PAPER_COLOR) >= 4.5,
+    `${pale.theme.text} (contrast=${contrastRatioHex(pale.theme.text, PAPER_COLOR).toFixed(2)})`);
   // Empty palette while harmonising → sticker-palette fallback + a note.
   check("adaptive with no template palette warns about the fallback", resolveTheme({ harmony: "complement", templatePalette: [] }).warnings.some((w) => w.includes("sticker palette")));
-  // fontPersonality is an orthogonal axis: it swaps fonts but NOT the gold palette.
+  // fontPersonality is an orthogonal axis: it swaps fonts but NOT the palette.
   const hand = resolveTheme({ fontPersonality: "handwritten" });
-  check("fontPersonality=handwritten sets Caveat body / keeps gold palette", hand.theme.fonts?.body === "Caveat" && hand.theme.text === GOLD, JSON.stringify(hand.theme.fonts));
+  check("fontPersonality=handwritten sets Caveat body / keeps the default palette", hand.theme.fonts?.body === "Caveat" && hand.theme.text === DEFAULT_INK, JSON.stringify(hand.theme.fonts));
+  // A chapter's paletteCharacter is a lower-precedence default source than harmony/accent/preset.
+  const sunbaked = resolveTheme({ paletteCharacter: "sunbaked" });
+  const tidewater = resolveTheme({ paletteCharacter: "tidewater" });
+  check("a different paletteCharacter resolves a different default ink colour", sunbaked.theme.text !== tidewater.theme.text, `${sunbaked.theme.text} vs ${tidewater.theme.text}`);
+  check("paletteCharacter's resolved ink still clears the contrast floor", contrastRatioHex(sunbaked.theme.text, PAPER_COLOR) >= 4.5);
+  check("an explicit accent still wins over paletteCharacter", resolveTheme({ paletteCharacter: "sunbaked", accent: "#7B5EA7" }).theme.text !== sunbaked.theme.text);
   // End-to-end: fontPersonality flows into the composed text.
   const written = await writeUnderlay(root, daily, { status: "ready", dryRun: true, fontPersonality: "handwritten", regions: [{ region: "todo", lines: [{ text: "buy milk" }] }] });
   check("fontPersonality reaches the composed ai.svg (Caveat body text)", (regionGroup(written.aiSvg, "todo") ?? "").includes('font-family="Caveat"'), regionGroup(written.aiSvg, "todo") ?? "");
@@ -568,7 +585,7 @@ async function main() {
   check("chapter high-variety gives banner-pill headings", /<rect[^>]*rx="6"/.test(fcg), fcg.slice(0, 200));
   // Per-call preset overrides the chapter's adaptive default.
   const overridden = regionGroup((await writeUnderlay(root, daily, { status: "ready", dryRun: true, theme: "gold", regions: [{ region: "todo", lines: [{ text: "Plain", heading: true }] }] })).aiSvg, "todo") ?? "";
-  check("per-call theme:gold overrides the chapter's adaptive theme", overridden.includes(`stroke="${GOLD}"`) && !/<rect[^>]*rx="6"/.test(overridden), overridden.slice(0, 200));
+  check("per-call theme:gold overrides the chapter's adaptive theme", overridden.includes(`stroke="${DEFAULT_INK}"`) && !/<rect[^>]*rx="6"/.test(overridden), overridden.slice(0, 200));
   // Restore the folder so later assertions see no theme.
   delete folderJson.theme;
   await fs.writeFile(dailyFolder, JSON.stringify(folderJson, null, 2) + "\n");
@@ -818,15 +835,23 @@ async function main() {
   const weekdaysRegion = monthlyRegions.find((r) => r.name === "weekdays");
   check("weekdays region derives as shared, not ai", !weekdaysRegion || weekdaysRegion.fill !== "ai", weekdaysRegion?.fill);
 
-  console.log("\npreset themes respect the cream-legibility floor (AA text)");
+  console.log("\npreset themes respect Rule 1's real WCAG contrast floor (AA text)");
   // The bright preset's accent (#E86A92, ~2.9:1 on cream) is calendar day-number TEXT —
-  // presets must pass through the same lightness floor the adaptive path uses.
+  // presets must clear the same ≥4.5:1 floor the adaptive path uses.
   for (const name of ["bright", "cozy", "editorial"]) {
     const t = resolveTheme(name).theme;
-    check(`${name}: text/serif floored dark`, hexToHsl(t.text).l <= 0.36 && hexToHsl(t.serif).l <= 0.36, `text ${t.text} serif ${t.serif}`);
-    check(`${name}: accent floored for cream`, hexToHsl(t.accent).l <= 0.48, `${t.accent} (L=${hexToHsl(t.accent).l.toFixed(2)})`);
+    check(`${name}: text/serif clear the contrast floor`,
+      contrastRatioHex(t.text, PAPER_COLOR) >= 4.5 && contrastRatioHex(t.serif, PAPER_COLOR) >= 4.5,
+      `text ${t.text} serif ${t.serif}`);
+    check(`${name}: accent clears the contrast floor`,
+      contrastRatioHex(t.accent, PAPER_COLOR) >= 4.5,
+      `${t.accent} (contrast=${contrastRatioHex(t.accent, PAPER_COLOR).toFixed(2)})`);
   }
-  check("gold preset is untouched (the canonical value)", resolveTheme("gold").theme.text === GOLD && resolveTheme("gold").theme.accent === GOLD);
+  // "gold" is kept only as a back-compat preset name — it no longer emits a fixed
+  // colour (gold is retired); it resolves to the same default ink-palette theme as no
+  // theme at all.
+  check("gold preset resolves to the default ink-palette theme, not a fixed hex",
+    resolveTheme("gold").theme.text === DEFAULT_INK && resolveTheme("gold").theme.accent === resolveTheme({}).theme.accent);
 
   console.log("\nwrite_underlay (raw svg) + reject merge+svg");
   const rawOk = await writeUnderlay(root, daily, {

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -349,7 +349,9 @@ async function main() {
   // 09:00 -> row 2, 10:00 -> row 3, given the schedule's own startHour 7 / rowsPerHour 1.
   check("block y matches the start row (09:00 -> row 2)", yAttr === Math.round(rl[2]), `y=${yAttr} expected=${Math.round(rl[2])}`);
   check("block height spans start->end row (10:00 -> row 3)", yAttr + hAttr === Math.round(rl[3]), `y+h=${yAttr + hAttr} expected=${Math.round(rl[3])}`);
-  check("block reuses the rx=6 corner-radius convention", rectMatch![0].includes('rx="6"'), rectMatch?.[0]);
+  // rx=8 / 0.16 tint per the 2026-07-09 washi spec (design/UNDERLAY-VISUAL.md, forthcoming).
+  check("block uses the washi rx=8 corner radius", rectMatch![0].includes('rx="8"'), rectMatch?.[0]);
+  check("block uses the 0.16 default tint opacity", rectMatch![0].includes('fill-opacity="0.16"'), rectMatch?.[0]);
   check("block draws the label text inside it", washiGroup.includes(">Team sync</text>"), washiGroup.slice(0, 300));
   // The tape's right inset should be the standard margin (24px), not a re-subtraction of the
   // schedule's wide LEFT gutter (52px, reserved for the printed hour labels) — that double-charge
@@ -386,27 +388,58 @@ async function main() {
     longTexts.join(" | "),
   );
 
+  // Min block height is one schedule-line interval read from the template's ruled
+  // lines (2026-07-09 washi spec) — a too-short/backwards range still draws a visible
+  // one-interval tape, superseding the old plain-time-line fallback (#17).
   const zeroDur = await writeUnderlay(root, daily, {
     status: "ready", dryRun: true,
     regions: [{ region: "schedule", lines: [{ text: "Oops", time: "10:00", endTime: "09:00" }] }],
   });
+  const zeroGroup = regionGroup(zeroDur.aiSvg, "schedule") ?? "";
+  const zeroRect = zeroGroup.match(/<rect[^>]*fill-opacity="[\d.]+"[^>]*\/>/);
   check(
-    "zero/negative duration warns (info) and falls back to a plain time line — the event still appears",
-    zeroDur.warningDetails.some((w) => w.code === "washi_block_zero_duration" && w.severity === "info") &&
-      (zeroDur.aiSvg ?? "").includes(">Oops</text>") &&
-      !(regionGroup(zeroDur.aiSvg, "schedule") ?? "").includes('rx="6"'),
+    "zero/negative duration draws a one-interval minimum block and warns (info)",
+    zeroDur.warningDetails.some((w) => w.code === "washi_block_min_height" && w.severity === "info") &&
+      !!zeroRect &&
+      zeroGroup.includes(">Oops</text>"),
     JSON.stringify(zeroDur.warningDetails),
   );
-  // The real-world case that motivated the fallback: a 20-minute meeting on a
-  // 1-row-per-hour grid snaps both ends to the same row — it must not vanish.
+  // 10:00 -> row 3 on this grid; the minimum block spans exactly one ruled interval.
+  const zeroH = Number(zeroRect?.[0].match(/height="(\d+)"/)?.[1]);
+  const oneInterval = Math.round(rl[4]) - Math.round(rl[3]);
+  check(
+    "minimum block height equals one ruled-line interval from the template",
+    zeroH === oneInterval,
+    `height=${zeroH} interval=${oneInterval}`,
+  );
+  // The real-world case that motivated #17's old fallback: a 20-minute meeting on a
+  // 1-row-per-hour grid snaps both ends to the same row — it must not vanish. It now
+  // draws the one-interval minimum tape instead of degrading to a bare time line.
   const shortMeeting = await writeUnderlay(root, daily, {
     status: "ready", dryRun: true,
     regions: [{ region: "schedule", lines: [{ text: "Morning Meeting", time: "08:00", endTime: "08:20" }] }],
   });
+  const shortGroup = regionGroup(shortMeeting.aiSvg, "schedule") ?? "";
   check(
-    "a sub-row meeting (08:00-08:20) keeps its text as a time line",
-    (shortMeeting.aiSvg ?? "").includes(">Morning Meeting</text>"),
-    (regionGroup(shortMeeting.aiSvg, "schedule") ?? "").slice(0, 300),
+    "a sub-row meeting (08:00-08:20) draws a minimum-height block, label inside",
+    shortGroup.includes(">Morning Meeting</text>") &&
+      /<rect[^>]*fill-opacity="[\d.]+"/.test(shortGroup) &&
+      shortMeeting.warningDetails.some((w) => w.code === "washi_block_min_height"),
+    shortGroup.slice(0, 300),
+  );
+  // The one geometry no block can fit: an event starting on the grid's LAST ruled
+  // line has no next line to span to — only there does the plain-time-line fallback
+  // survive.
+  const lastLineHour = 7 + (rl.length - 1); // schedule startHour 7, rowsPerHour 1
+  const lastLine = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "schedule", lines: [{ text: "Nightcap", time: `${String(lastLineHour).padStart(2, "0")}:00`, durationMin: 30 }] }],
+  });
+  check(
+    "an event on the grid's last ruled line falls back to a plain time line",
+    lastLine.warningDetails.some((w) => w.code === "washi_block_zero_duration" && w.severity === "info") &&
+      (lastLine.aiSvg ?? "").includes(">Nightcap</text>"),
+    JSON.stringify(lastLine.warningDetails),
   );
 
   const overrun = await writeUnderlay(root, daily, {
@@ -436,15 +469,17 @@ async function main() {
   // endTime + durationMin together are rejected at the MCP schema (index.ts .refine,
   // mirroring marker/icon) — not reachable through this direct compose path. At the
   // compose layer itself, confirm `endTime` takes precedence (a 15-min durationMin
-  // from 09:00 would round to the SAME row and warn zero-duration; endTime "10:00"
-  // must win instead, drawing a real block with no such warning).
+  // from 09:00 would round to the SAME row and clamp to the one-interval minimum;
+  // endTime "10:00" must win instead, drawing a real block with no clamp warning).
   const bothSet = await writeUnderlay(root, daily, {
     status: "ready", dryRun: true,
     regions: [{ region: "schedule", lines: [{ text: "x", time: "09:00", endTime: "10:00", durationMin: 15 } as any] }],
   });
   check(
     "endTime takes precedence over durationMin if both are set on one line",
-    !bothSet.warningDetails.some((w) => w.code === "washi_block_zero_duration"),
+    !bothSet.warningDetails.some(
+      (w) => w.code === "washi_block_zero_duration" || w.code === "washi_block_min_height",
+    ),
     JSON.stringify(bothSet.warningDetails),
   );
 
@@ -795,7 +830,7 @@ async function main() {
   console.log("\nmerge over a prior raw-svg document warns instead of silently dropping it");
   await writeUnderlay(root, daily, {
     status: "ready",
-    svg: '<svg viewBox="0 0 1024 1366" xmlns="http://www.w3.org/2000/svg"><text x="80" y="80" fill="#9C7C1A">raw only</text></svg>',
+    svg: '<svg viewBox="0 0 1024 1366" xmlns="http://www.w3.org/2000/svg"><text x="80" y="80" fill="#4A6FA5">raw only</text></svg>',
   });
   const mergeOverRaw = await writeUnderlay(root, daily, {
     status: "ready", merge: true,
@@ -856,7 +891,7 @@ async function main() {
   console.log("\nwrite_underlay (raw svg) + reject merge+svg");
   const rawOk = await writeUnderlay(root, daily, {
     status: "ready",
-    svg: '<svg viewBox="0 0 1024 1366" xmlns="http://www.w3.org/2000/svg"><text x="80" y="80" fill="#9C7C1A">raw</text></svg>',
+    svg: '<svg viewBox="0 0 1024 1366" xmlns="http://www.w3.org/2000/svg"><text x="80" y="80" fill="#4A6FA5">raw</text></svg>',
   });
   check("raw svg written verbatim", (await fs.readFile(aiPath, "utf8")).includes(">raw</text>"));
   check("supported raw svg produces no raw warnings", rawOk.warningDetails.length === 0, JSON.stringify(rawOk.warningDetails));
@@ -1130,7 +1165,7 @@ async function main() {
   console.log("\nraw fragments accept the app renderer's full element set");
   const shapes = await writeUnderlay(root, daily, {
     status: "ready", dryRun: true,
-    regions: [{ region: "ainotes", svg: '<ellipse cx="40" cy="40" rx="20" ry="10" fill="none" stroke="#9C7C1A"/><polyline points="0,0 10,10 20,0" fill="none" stroke="#9C7C1A"/><polygon points="0,0 10,10 0,10" fill="#9C7C1A"/>' }],
+    regions: [{ region: "ainotes", svg: '<ellipse cx="40" cy="40" rx="20" ry="10" fill="none" stroke="#4A6FA5"/><polyline points="0,0 10,10 20,0" fill="none" stroke="#4A6FA5"/><polygon points="0,0 10,10 0,10" fill="#4A6FA5"/>' }],
   });
   check("ellipse/polyline/polygon produce no unsupported-element warning", !shapes.warningDetails.some((w) => w.code === "raw_svg_unsupported_element"), JSON.stringify(shapes.warningDetails));
 
@@ -1385,7 +1420,7 @@ async function main() {
   console.log("\nraw svg size guard");
   const hugeRaw = await writeUnderlay(root, daily, {
     status: "ready", dryRun: true,
-    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1366"><!-- ${"x".repeat(300 * 1024)} --><rect x="1" y="1" width="2" height="2" fill="#9C7C1A"/></svg>`,
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1366"><!-- ${"x".repeat(300 * 1024)} --><rect x="1" y="1" width="2" height="2" fill="#4A6FA5"/></svg>`,
   });
   check("a >256KB raw svg warns (raw_svg_large)",
     hugeRaw.warningDetails.some((w) => w.code === "raw_svg_large"), JSON.stringify(hugeRaw.warningDetails.map((w) => w.code)));
@@ -1405,6 +1440,96 @@ async function main() {
   check("accented page drops the gold default", !/#9C7C1A/i.test(accentTodoGroup), accentTodoGroup.slice(0, 400));
   check("accented page tints body text (non-gold fill present)", /<text[^>]*fill="#[0-9a-fA-F]{6}"/.test(accentTodoGroup), accentTodoGroup.slice(0, 400));
   // Clean up so later assertions see a pristine folder (writeChapterTheme only merges).
+  {
+    const f = JSON.parse(await fs.readFile(path.join(root, "Shared", "Daily", ".folder.json"), "utf8"));
+    delete f.theme;
+    await fs.writeFile(path.join(root, "Shared", "Daily", ".folder.json"), JSON.stringify(f, null, 2) + "\n");
+  }
+
+  console.log("\nchapter paletteCharacter + chromeAccent → the chapter's own colours");
+  const chapterAccent = "#7A3F73"; // orchard's plum, as the chapter chrome accent
+  await writeChapterTheme(root, "Daily", {
+    paletteCharacter: "orchard",
+    chromeAccent: chapterAccent,
+    customInk1: "#2F6E57",
+    displayName: "orchard days",
+  });
+  const charFolder = JSON.parse(await fs.readFile(path.join(root, "Shared", "Daily", ".folder.json"), "utf8"));
+  check(
+    "set_chapter_theme writes paletteCharacter/customInk1/displayName additively",
+    charFolder.theme?.paletteCharacter === "orchard" &&
+      charFolder.theme?.customInk1 === "#2F6E57" &&
+      charFolder.theme?.displayName === "orchard days",
+    JSON.stringify(charFolder.theme),
+  );
+  const charRead = await readPage(root, daily);
+  // read_page's `underlay` block is the SAME resolution write_underlay uses — the
+  // advertised palette and the composed one can never drift.
+  const charOracle = resolveTheme({
+    paletteCharacter: "orchard",
+    customInk1: "#2F6E57",
+    chromeAccent: chapterAccent,
+  }).theme;
+  check(
+    "read_page.underlay advertises the resolved chapter palette",
+    charRead.underlay.text === charOracle.text &&
+      charRead.underlay.accent === charOracle.accent &&
+      charRead.underlay.washiTint === chapterAccent,
+    JSON.stringify(charRead.underlay),
+  );
+  check(
+    "read_page.theme surfaces the new additive keys",
+    charRead.theme?.paletteCharacter === "orchard" && charRead.theme?.displayName === "orchard days",
+    JSON.stringify(charRead.theme),
+  );
+  check(
+    "the resolved chapter text colour clears the contrast floor on this page's paper",
+    contrastRatioHex(charRead.underlay.text, charRead.template.paperColor) >= 4.5,
+    charRead.underlay.text,
+  );
+  const charWrite = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [
+      { region: "todo", lines: [{ text: "Water the beds", marker: "checkbox" }] },
+      { region: "schedule", lines: [{ text: "Studio", time: "09:00", endTime: "10:00" }] },
+    ],
+  });
+  const charTodo = regionGroup(charWrite.aiSvg, "todo") ?? "";
+  const charSched = regionGroup(charWrite.aiSvg, "schedule") ?? "";
+  check(
+    "a default write composes body text in the advertised underlay colour",
+    charTodo.includes(`fill="${charRead.underlay.text}"`),
+    charTodo.slice(0, 300),
+  );
+  check(
+    "washi duration blocks tint with the chapter's chromeAccent (raw, no darkening)",
+    new RegExp(`<rect[^>]*fill="${chapterAccent}" fill-opacity="0.16"`).test(charSched),
+    charSched.slice(0, 300),
+  );
+
+  console.log("\nRule 1 on per-line overrides: text fills floored, no-text fills raw");
+  const paleHex = "#F2B8CC"; // fails 4.5:1 on paper by a wide margin
+  const paleWrite = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [
+      { region: "todo", lines: [{ text: "pale text", fill: paleHex }] },
+      { region: "schedule", lines: [{ text: "pale tape", time: "09:00", endTime: "11:00", blockFill: paleHex }] },
+    ],
+  });
+  const paleTodo = regionGroup(paleWrite.aiSvg, "todo") ?? "";
+  const paleFill = paleTodo.match(/<text[^>]*fill="(#[0-9a-fA-F]{6})"/)?.[1];
+  check(
+    "a too-pale per-line text fill is auto-darkened to the contrast floor",
+    !!paleFill && paleFill.toLowerCase() !== paleHex.toLowerCase() &&
+      contrastRatioHex(paleFill!, PAPER_COLOR) >= 4.5,
+    `emitted=${paleFill}`,
+  );
+  check(
+    "the same pale hex passes through VERBATIM as a washi blockFill (no text on it)",
+    (regionGroup(paleWrite.aiSvg, "schedule") ?? "").includes(`fill="${paleHex}"`),
+    (regionGroup(paleWrite.aiSvg, "schedule") ?? "").slice(0, 300),
+  );
+  // Clean up the chapter theme again for downstream assertions.
   {
     const f = JSON.parse(await fs.readFile(path.join(root, "Shared", "Daily", ".folder.json"), "utf8"));
     delete f.theme;


### PR DESCRIPTION
## Summary
- Retires the gold underlay seed entirely; default underlay palette now derives from the chapter's `paletteCharacter` (or a calm default), lifted lighter than user ink and floored at a real ≥4.5:1 WCAG contrast ratio.
- Washi/duration blocks follow the 2026-07-09 spec: rx 6→8, tint opacity 0.22→0.16, tint defaults to the chapter's `chromeAccent`, and min block height = one schedule-line interval read from the template's ruled lines.
- `read_page` now returns the resolved `underlay` palette via the same `resolveThemeInput → resolveTheme` path `write_underlay` uses.
- Adds the `AUTHORING.md` hard rule: one text box per logical block, never one per line.

Closes #18, #19, #20 (see commit messages 514779a, 53b1ba1 for full detail).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run smoke` — 279/279 passing (per commit message)