### PR TITLE
read_page exposes each region's printed text (#9)

### DIFF
--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -29,6 +29,13 @@ its level; don't fight it.**
 
 When in doubt, under-decorate — the user chose that template on purpose.
 
+Per-region, check `printedText` (from `read_page`'s `regions`) before writing a line — it's
+the template's own `<text>` content already drawn inside that region's box (a section label,
+chrome like "TODAY"/"DATE", a weekday header, hour-line numbers). If a region already prints
+the date, don't also write a line spelling it out; if it already labels itself ("Schedule"),
+skip a redundant `label`. Read it instead of memorizing which templates print what — templates
+change.
+
 ## Who fills a region — `fill` and `intent`
 
 Ownership in Onionskin is by *layer* — you write `ai.svg`, the user owns `ink.svg`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,27 @@ roadmap holds only planned feature development (bugs/polish live on the
 
 ---
 
+## `read_page` exposes each region's printed text — 2026-07-09
+
+Closes [#9](https://github.com/bsitkoff/onion_planner_mcp/issues/9). An orchestrator had no
+way to see that a template already prints chrome (e.g. daily-minimal's header prints "TODAY")
+short of memorizing per-template facts — the 2026-07-05 morning run wrote "Sunday, July 5" as
+a text line under a date banner the template already drew.
+
+- `template.ts`: `Region` gains `printedText: string[]` — every `<text>` node's content
+  (trimmed, in document order) parsed directly out of that region's own `<g>` in
+  `template.svg`. Empty when the template prints nothing there.
+- `read_page`'s tool description documents it: check `printedText` before writing a line so
+  you don't double-write content the template already shows.
+- `docs/AUTHORING.md`: a short note pointing at `printedText` instead of memorized
+  per-template chrome facts.
+- `test/smoke.ts`: covers a template that prints chrome-only text (daily-minimal's "TODAY"),
+  a region with no `<text>` (empty array), and a styled template's section label + numeric
+  hour-line text (numbers, since fast-xml-parser parses numeric text content as `number` not
+  `string` — `textNodeContent` stringifies both). 267/267 passing · tsc clean.
+
+---
+
 ## Washi-tape blocks widened + long labels wrap — 2026-07-06
 
 The schedule's washi-tape duration block was subtracting its wide *left* gutter (reserved for

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -80,12 +80,14 @@ nightly/morning runs:
 2. **Server-side image downscale / fit-to-region sizing** — absorb the "resize it yourself
    with Python" chore the same way the server absorbed background knockout; `fit: "region"`
    ends hand-computed widths. [#8](https://github.com/bsitkoff/onion_planner_mcp/issues/8)
-3. **Expose the template's printed text via `read_page`** — so an orchestrator can see that
-   the template already prints the date/labels instead of memorizing "don't double-write the
-   date" in skill prose. [#9](https://github.com/bsitkoff/onion_planner_mcp/issues/9)
-4. **Region recommended-image-size signal** — replace the 35%-of-box heuristic behind
+3. **Region recommended-image-size signal** — replace the 35%-of-box heuristic behind
    `image_small_for_region` with a declared floor (template `data-*` key or per-intent
    default). [#10](https://github.com/bsitkoff/onion_planner_mcp/issues/10)
+
+**Shipped 2026-07-09:** expose the template's printed text via `read_page` (`printedText`
+per region) so an orchestrator can see that the template already prints the date/labels
+instead of memorizing "don't double-write the date" in skill prose —
+[#9](https://github.com/bsitkoff/onion_planner_mcp/issues/9); see `CHANGELOG.md`.
 
 ## Planned — blocked on the app
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,12 @@ server.tool(
   "read_page",
   "Read one shared page: its manifest, parsed regions (name, x, y, width, height, rows, " +
     "cols, startHour/rowsPerHour for timed grids, a `list` bucket, absolute ruled-line " +
-    "positions, a `fill`, a free-text `intent`, and `labelFilled` — whether a region's " +
+    "positions, a `fill`, a free-text `intent`, `printedText` — the template's own <text> " +
+    "content already drawn inside this region (a section label, chrome like \"TODAY\"/\"DATE\", " +
+    "a weekday header, hour-line numbers), in document order, empty if the template prints " +
+    "nothing here; check it before writing a line so you don't double-write content the " +
+    "template already shows (e.g. the date under a template that already prints \"TODAY\"), " +
+    "and `labelFilled` — whether a region's " +
     "printed label slot, if it has one, actually has a label banner drawn into it yet " +
     "(null if the region has no slot; false means the template prints a slot but nothing's " +
     "there — don't assume a slot means content exists, pass `label` to fill it)), current ai.svg, " +

--- a/src/template.ts
+++ b/src/template.ts
@@ -60,6 +60,15 @@ export interface Region {
    * placement for the region-title banner.
    */
   labelSlot: { x: number; y: number; width: number; height: number } | null;
+  /**
+   * Text the template itself already prints inside this region's `<g>` (a section
+   * label like "Schedule", chrome like "TODAY"/"DATE", a weekday header, hour-line
+   * numbers) — in document order. Empty when the template prints nothing here. Lets
+   * a caller check `printedText` before writing a line so it doesn't double-write
+   * content the template already draws (e.g. the date under a template that already
+   * prints "TODAY"), instead of relying on memorized per-template knowledge.
+   */
+  printedText: string[];
 }
 
 const parser = new XMLParser({
@@ -292,6 +301,19 @@ function readIntent(v: unknown): string | null {
 }
 
 /**
+ * A parsed `<text>` node's content — fast-xml-parser yields a bare value (string, or
+ * number when the content is numeric, e.g. an hour-line "7") for an attribute-free
+ * element, else an object keyed by `#text` holding that same bare value.
+ */
+function textNodeContent(node: unknown): string | null {
+  const raw =
+    typeof node === "object" && node !== null ? (node as any)["#text"] : node;
+  if (typeof raw !== "string" && typeof raw !== "number") return null;
+  const trimmed = String(raw).trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+/**
  * Parse a template.svg into its addressable regions. Reads every
  * <g id="region-*"> and reports its transform, box, row/col hints, the absolute
  * positions of its ruled lines, who fills it (`fill`), and the designer's free-text
@@ -359,6 +381,11 @@ export function parseRegions(templateSvg: string, templateName?: string): Region
     const intent = readIntent(g["@_data-intent"]);
     const list = readIntent(g["@_data-list"]); // same trim-or-null treatment
 
+    const textNodes: any[] = Array.isArray(g.text) ? g.text : g.text ? [g.text] : [];
+    const printedText = textNodes
+      .map(textNodeContent)
+      .filter((t): t is string => t !== null);
+
     regions.push({
       id,
       name,
@@ -376,6 +403,7 @@ export function parseRegions(templateSvg: string, templateName?: string): Region
       ruledLines,
       colLines,
       labelSlot,
+      printedText,
     });
   }
   return regions;

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -152,6 +152,18 @@ async function main() {
   // header's dashed art-banner rect has no data-region, so it's NOT a label slot.
   const header = read.regions.find((r) => r.name === "header");
   check("header's decorative dashed rect (no data-region) is not read as a label slot", header?.labelSlot === null, JSON.stringify(header?.labelSlot));
+  // printedText: the template's own <text> content per region — lets an orchestrator
+  // see that daily-minimal's header already prints "TODAY" chrome instead of relying
+  // on memorized per-template knowledge (the #9 double-date-write bug).
+  check("header region surfaces the template's printed \"TODAY\" chrome", !!header?.printedText.includes("TODAY"), JSON.stringify(header?.printedText));
+  check("schedule region (minimal, no <text>) reports an empty printedText", schedule?.printedText.length === 0, JSON.stringify(schedule?.printedText));
+  const cozyScheduleTemplateSvg = await fs.readFile(path.join(root, "Templates", "daily-cozy", "template.svg"), "utf8");
+  const cozyScheduleRegion = parseRegions(cozyScheduleTemplateSvg, "daily-cozy").find((r) => r.name === "schedule");
+  check(
+    "cozy's schedule region surfaces its section label + hour-line numbers in document order",
+    cozyScheduleRegion?.printedText[0] === "Schedule" && cozyScheduleRegion?.printedText.slice(1).includes("7"),
+    JSON.stringify(cozyScheduleRegion?.printedText),
+  );
   // Template inspection: minimal prints a faint "TODAY" microcap (hasLabels) but no
   // banners/art/palette — labels alone must NOT mark it styled, or the "bare → go
   // full" guidance would be unreachable on every shipped template. Cozy is fully


### PR DESCRIPTION
## Summary
- `Region` gains `printedText: string[]` — every `<text>` node's content (trimmed, document order) parsed out of that region's own `<g>` in `template.svg`. Empty when the template prints nothing there.
- `read_page`'s tool description documents it, telling the caller to check `printedText` before writing a line so it doesn't double-write content the template already shows (e.g. writing out "Sunday, July 5" under a template that already prints "TODAY" chrome).
- `docs/AUTHORING.md` points at `printedText` instead of memorized per-template facts.

Closes #9.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run smoke` — 267/267 passing, including new coverage: a template that prints chrome-only text, a region with no `<text>`, and a styled template's section label + numeric hour-line text (fast-xml-parser parses numeric text content as `number`, handled in `textNodeContent`)