### PR TITLE
Server-side image downscale + fit-to-region sizing (#8)

### DIFF
--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -285,6 +285,13 @@ area.
 `convert_to_webp`/`get_generated_webp_images` — onionskin rejects webp (that path is for
 WordPress). More detail in the project memory (`onionskin-image-gen-pipeline`).
 
+Two more knobs cut hand-computed sizing out of the loop: `images[].fit:"region"` sizes the
+display box to fit inside the region's own box (aspect-preserving contain, inset by `margin`)
+instead of you computing a `width` from `read_page` geometry — omit `width`/`height` entirely
+when you set it. `images[].maxDimension` downscales an over-large PNG source (re-encoded, not
+just resized on disk) so it clears the 1536px guideline / 2MB cap instead of you resizing it
+by hand first — PNG only; a JPEG over the limit still needs downscaling before sending.
+
 ### Getting *clean* art into the underlay (no checkerboard, no halo)
 
 Getting a **clean cutout** into the underlay is the fragile part of the pipeline — it depends

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,35 @@ roadmap holds only planned feature development (bugs/polish live on the
 
 ---
 
+## Server-side image downscale + fit-to-region sizing — 2026-07-09
+
+Closes [#8](https://github.com/bsitkoff/onion_planner_mcp/issues/8). The 2026-07-05
+morning-run transcript burned several rounds resizing PNGs with Python because the server's
+only response to an oversized image was to throw; separately, callers hand-computed a
+`width` from `read_page` geometry to fit an image into a region.
+
+- `images[].fit: "region"` — sizes the display box to fit inside the region's own box
+  (aspect-preserving contain, inset by `margin`), resolved once the region's geometry and the
+  image's intrinsic dimensions are both known (`page.ts:resolveImages`, now given the
+  template's parsed regions). Mutually exclusive with `width`/`height` — omit both.
+  `write_underlay` now parses template geometry *before* resolving images (previously after)
+  so this lookup is available.
+- `images[].maxDimension` — downscales an over-large source instead of throwing/warning,
+  re-encoding the actual bytes (not just resizing on disk beforehand). PNG only: a new
+  `resampleToMaxDimension` (`png.ts`) is a box-filter (area-average) downsample, chosen over
+  nearest-neighbor for less aliasing, sitting next to the existing hand-rolled codec
+  (`decodePng`/`encodePng`/`chromaKeyPixels`). A JPEG source over the limit still throws a
+  clear error — no JPEG decoder in this codebase's minimal PNG-only codec.
+- New `image_downscaled` info warning reports the before/after dimensions when
+  `maxDimension` triggers a resample.
+- `docs/AUTHORING.md` documents both knobs in the image-sourcing recipe.
+- `test/smoke.ts`: covers `fit: "region"`'s computed size (derived from parsed geometry, not
+  hard-coded), the `fit`+explicit-`width` mutual-exclusion error, a real PNG resampled and
+  re-written smaller on disk, the `image_downscaled` warning, and the JPEG+`maxDimension`
+  error. 269/269 passing · tsc clean.
+
+---
+
 ## Washi-tape blocks widened + long labels wrap — 2026-07-06
 
 The schedule's washi-tape duration block was subtracting its wide *left* gutter (reserved for

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -77,15 +77,17 @@ nightly/morning runs:
    run can *see* what it wrote (every recent failure a human caught by eye would have been
    visible); day-end wants the same composite for ink cross-checks. Rasterizer-dependency
    decision lives in the issue. [#7](https://github.com/bsitkoff/onion_planner_mcp/issues/7)
-2. **Server-side image downscale / fit-to-region sizing** — absorb the "resize it yourself
-   with Python" chore the same way the server absorbed background knockout; `fit: "region"`
-   ends hand-computed widths. [#8](https://github.com/bsitkoff/onion_planner_mcp/issues/8)
-3. **Expose the template's printed text via `read_page`** — so an orchestrator can see that
+2. **Expose the template's printed text via `read_page`** — so an orchestrator can see that
    the template already prints the date/labels instead of memorizing "don't double-write the
    date" in skill prose. [#9](https://github.com/bsitkoff/onion_planner_mcp/issues/9)
-4. **Region recommended-image-size signal** — replace the 35%-of-box heuristic behind
+3. **Region recommended-image-size signal** — replace the 35%-of-box heuristic behind
    `image_small_for_region` with a declared floor (template `data-*` key or per-intent
    default). [#10](https://github.com/bsitkoff/onion_planner_mcp/issues/10)
+
+**Shipped 2026-07-09:** server-side image downscale / fit-to-region sizing —
+`images[].fit:"region"` ends hand-computed widths, `images[].maxDimension` downscales an
+over-large PNG instead of throwing — [#8](https://github.com/bsitkoff/onion_planner_mcp/issues/8);
+see `CHANGELOG.md`.
 
 ## Planned — blocked on the app
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -394,14 +394,22 @@ const imageSchema = z.object({
     .string()
     .optional()
     .describe("Stable filename stem — re-writing the same name replaces the image. Defaults to a content hash."),
-  width: z.number().positive().describe("Display width in region-local units."),
+  width: z
+    .number()
+    .positive()
+    .optional()
+    .describe(
+      "Display width in region-local units. Required unless `fit: \"region\"` computes it " +
+        "from the region's own box.",
+    ),
   height: z
     .number()
     .positive()
     .optional()
     .describe(
       "Display height. OMIT to aspect-fill from the source (recommended) — a height off " +
-        "the source aspect renders visibly stretched and trips `image_aspect_mismatch`.",
+        "the source aspect renders visibly stretched and trips `image_aspect_mismatch`. Not " +
+        "allowed with `fit: \"region\"` (it computes both dimensions).",
     ),
   x: z.number().optional().describe("Region-local x. Overrides `corner`."),
   y: z.number().optional().describe("Region-local y. Overrides `corner`."),
@@ -409,7 +417,30 @@ const imageSchema = z.object({
     .enum(["top-left", "top-right", "bottom-left", "bottom-right", "center"])
     .optional()
     .describe("Placement within the region box (default center). Ignored if x/y are set."),
-  margin: z.number().optional().describe("Inset from the region edge for corner placement (default 8)."),
+  margin: z
+    .number()
+    .optional()
+    .describe(
+      "Inset from the region edge for corner placement (default 8). Also the box inset " +
+        "`fit: \"region\"` sizes inside.",
+    ),
+  fit: z
+    .literal("region")
+    .optional()
+    .describe(
+      "Size the display box to fit inside the region's own box (aspect-preserving contain, " +
+        "inset by `margin`) instead of computing `width`/`height` yourself from read_page " +
+        "geometry. Mutually exclusive with `width`/`height` — omit both when set.",
+    ),
+  maxDimension: z
+    .number()
+    .positive()
+    .optional()
+    .describe(
+      "Downscale the source so neither dimension exceeds this, before sizing/hashing/writing " +
+        "— use instead of resizing a source image by hand to clear the 1536px guideline or " +
+        "2MB cap. PNG sources only today (re-encodes pixels); a JPEG over the limit still throws.",
+    ),
   opacity: z.number().min(0).max(1).optional().describe("Image opacity, 0–1."),
   knockout: z
     .enum(["subject", "chroma", "none"])
@@ -443,6 +474,10 @@ const imageSchema = z.object({
   message: '`chromaColor` is required when knockout is "chroma".',
 }).refine((i) => i.knockout === "chroma" || (i.chromaColor === undefined && i.tolerance === undefined), {
   message: '`chromaColor`/`tolerance` only apply when knockout is "chroma".',
+}).refine((i) => i.fit !== "region" || (i.width === undefined && i.height === undefined), {
+  message: '`fit: "region"` computes width/height itself — omit both.',
+}).refine((i) => i.fit === "region" || i.width !== undefined, {
+  message: "`width` is required unless `fit` is \"region\".",
 });
 
 server.tool(

--- a/src/page.ts
+++ b/src/page.ts
@@ -26,7 +26,7 @@ import {
   type ThemeInput,
   type WarningDetail,
 } from "./svg.js";
-import { decodePng, encodePng, chromaKeyPixels } from "./png.js";
+import { decodePng, encodePng, chromaKeyPixels, resampleToMaxDimension } from "./png.js";
 
 /**
  * The underlay-relevant slice of a chapter's `.folder.json → theme` (the app's
@@ -446,15 +446,20 @@ export interface ResolveImagesDeps {
  * Decode, validate, size, and (unless dryRun) write each region's images into the
  * page's `media/ai/` folder, mutating each `ImageInput` in place with its resolved
  * `href`/`width`/`height` so `composeAiSvg` can reference it. Returns soft warnings.
+ * `geometry` (the template's parsed regions) resolves `fit: "region"` sizing —
+ * looked up by name, since `RegionInput` (the caller's write_underlay payload)
+ * carries no box geometry of its own.
  */
 async function resolveImages(
   pageAbs: string,
   regions: RegionInput[],
+  geometry: Region[],
   dryRun: boolean,
   deps: ResolveImagesDeps = {},
 ): Promise<{ warnings: string[]; warningDetails: WarningDetail[] }> {
   const warnings: string[] = [];
   const warningDetails: WarningDetail[] = [];
+  const geometryByName = new Map(geometry.map((r) => [r.name, r]));
   const mediaAiAbs = path.join(pageAbs, MEDIA_AI);
   // Filenames already claimed in THIS write (file → content sha) — two different
   // images sharing a `name` must not silently overwrite each other.
@@ -464,7 +469,14 @@ async function resolveImages(
       if ((img.data === undefined) === (img.path === undefined)) {
         throw new Error(`image in region "${region.region}" needs exactly one of \`data\` (base64) or \`path\`.`);
       }
-      if (img.width === undefined || img.width <= 0) {
+      if (img.fit === "region") {
+        if (img.width !== undefined || img.height !== undefined) {
+          throw new Error(
+            `image in region "${region.region}": fit:"region" computes width/height from the ` +
+              "region's own box — don't also pass `width`/`height`.",
+          );
+        }
+      } else if (img.width === undefined || img.width <= 0) {
         throw new Error(`image in region "${region.region}" needs a positive \`width\`.`);
       }
       // Source the bytes: a local file (no base64 through context) or inline base64.
@@ -503,9 +515,63 @@ async function resolveImages(
             `("png" or "jpeg"), the bytes are neither.`,
         );
       }
-      const dims = imageDims(buf, format); // also validates the magic bytes
-      const width = img.width;
-      const height = img.height ?? Math.round((width * dims.height) / dims.width);
+      let dims = imageDims(buf, format); // also validates the magic bytes
+
+      // maxDimension: downscale instead of just warning/throwing. Only PNG can be
+      // decoded/re-encoded here (see png.ts's deliberately narrow scope) — a JPEG
+      // source over the limit still needs downscaling by hand.
+      if (img.maxDimension !== undefined && Math.max(dims.width, dims.height) > img.maxDimension) {
+        if (format !== "png") {
+          throw new Error(
+            `image in region "${region.region}": maxDimension downscale only supports PNG ` +
+              `sources today (got ${format}) — convert to PNG or downscale before sending.`,
+          );
+        }
+        const before = dims;
+        let decoded;
+        try {
+          decoded = decodePng(buf);
+        } catch (e) {
+          throw new Error(`image in region "${region.region}": ${(e as Error).message}`);
+        }
+        const resampled = resampleToMaxDimension(decoded, img.maxDimension);
+        buf = encodePng(resampled);
+        checkImageSize(buf, region.region, warnings, warningDetails);
+        dims = { width: resampled.width, height: resampled.height };
+        const message =
+          `region "${region.region}": image downscaled ${before.width}×${before.height} → ` +
+          `${dims.width}×${dims.height} (maxDimension ${img.maxDimension}).`;
+        warnings.push(message);
+        warningDetails.push({ code: "image_downscaled", severity: "info", region: region.region, message });
+      }
+
+      let width: number;
+      let height: number;
+      if (img.fit === "region") {
+        const geo = geometryByName.get(region.region);
+        if (!geo || geo.width === null || geo.height === null) {
+          throw new Error(
+            `image in region "${region.region}": fit:"region" needs a region with a known box ` +
+              `— no box geometry found for "${region.region}".`,
+          );
+        }
+        const margin = img.margin ?? 8;
+        const boxW = geo.width - margin * 2;
+        const boxH = geo.height - margin * 2;
+        if (boxW <= 0 || boxH <= 0) {
+          throw new Error(
+            `image in region "${region.region}": fit:"region" box is too small for margin ` +
+              `${margin} (region box is ${geo.width}×${geo.height}).`,
+          );
+        }
+        const scale = Math.min(boxW / dims.width, boxH / dims.height);
+        width = Math.round(dims.width * scale);
+        height = Math.round(dims.height * scale);
+      } else {
+        width = img.width!;
+        height = img.height ?? Math.round((width * dims.height) / dims.width);
+      }
+
       if (Math.max(dims.width, dims.height) > WARN_IMAGE_DIMENSION) {
         const message =
           `region "${region.region}": image is ${dims.width}×${dims.height}px — over the ` +
@@ -848,11 +914,12 @@ export async function writeUnderlay(
       warningDetails.push({ code: "raw_svg_large", severity: "warning", message });
     }
   } else if (opts.regions) {
-    // Resolve images first (writes media/ai/ files, fills each image's href) so the
-    // composed ai.svg never references a file that isn't on disk yet.
-    const imageResult = await resolveImages(abs, opts.regions, opts.dryRun ?? false, deps);
+    // Parse the template's geometry first — resolveImages needs it (fit: "region"
+    // sizing looks up each region's box by name) before it writes media/ai/ files
+    // and fills each image's href, ahead of composeAiSvg.
     const templateSvg = await readIfExists(path.join(abs, "template.svg"));
     const regions = templateSvg ? parseRegions(templateSvg, manifest.template) : [];
+    const imageResult = await resolveImages(abs, opts.regions, regions, opts.dryRun ?? false, deps);
     const size = pageSize(manifest, templateSvg);
     const themeInput = await resolveThemeInput(abs, templateSvg, opts);
     const composed = composeAiSvg(size, opts.regions, regions, themeInput, manifest.template);

--- a/src/png.ts
+++ b/src/png.ts
@@ -212,6 +212,49 @@ export function encodePng(img: DecodedPng): Buffer {
 }
 
 /**
+ * Downscale so neither dimension exceeds `maxDimension`, aspect preserved — a
+ * box-filter (area-average) resample, chosen over nearest-neighbor for less
+ * aliasing on AI-generated art with no extra dependency. Returns `img` unchanged
+ * if it's already within `maxDimension` (never upscales). Alpha is averaged
+ * alongside colour channels — an approximation (ignores premultiplication) that's
+ * fine for the mostly-opaque-or-fully-transparent art this serves (see
+ * `page.ts`'s `images[].maxDimension`).
+ */
+export function resampleToMaxDimension(img: DecodedPng, maxDimension: number): DecodedPng {
+  const scale = maxDimension / Math.max(img.width, img.height);
+  if (scale >= 1) return img;
+  const { width: srcW, height: srcH, pixels: src } = img;
+  const dstW = Math.max(1, Math.round(srcW * scale));
+  const dstH = Math.max(1, Math.round(srcH * scale));
+  const dst = new Uint8Array(dstW * dstH * 4);
+  for (let dy = 0; dy < dstH; dy++) {
+    const sy0 = Math.floor((dy * srcH) / dstH);
+    const sy1 = Math.max(sy0 + 1, Math.floor(((dy + 1) * srcH) / dstH));
+    for (let dx = 0; dx < dstW; dx++) {
+      const sx0 = Math.floor((dx * srcW) / dstW);
+      const sx1 = Math.max(sx0 + 1, Math.floor(((dx + 1) * srcW) / dstW));
+      let r = 0, g = 0, b = 0, a = 0, count = 0;
+      for (let sy = sy0; sy < sy1; sy++) {
+        for (let sx = sx0; sx < sx1; sx++) {
+          const i = (sy * srcW + sx) * 4;
+          r += src[i];
+          g += src[i + 1];
+          b += src[i + 2];
+          a += src[i + 3];
+          count++;
+        }
+      }
+      const o = (dy * dstW + dx) * 4;
+      dst[o] = Math.round(r / count);
+      dst[o + 1] = Math.round(g / count);
+      dst[o + 2] = Math.round(b / count);
+      dst[o + 3] = Math.round(a / count);
+    }
+  }
+  return { width: dstW, height: dstH, pixels: dst };
+}
+
+/**
  * Key a solid background colour to transparent, in place. Per-pixel: if every
  * channel is within `tolerance` of `target`, set alpha to 0. A hard cutoff — no
  * edge feathering (a real anti-aliasing decision, left as a documented v1

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -446,9 +446,12 @@ export interface ImageInput {
   format?: "png" | "jpeg";
   /** Stable filename stem; defaults to a content hash. Sanitized in page.ts. */
   name?: string;
-  /** Display width in region-local units (required). */
+  /**
+   * Display width in region-local units. Required unless `fit: "region"` computes
+   * it from the region's own box.
+   */
   width?: number;
-  /** Display height; omitted = preserve aspect from the decoded image. */
+  /** Display height; omitted = preserve aspect from the decoded image. Ignored with `fit: "region"`. */
   height?: number;
   /** Region-local x (overrides `corner`). */
   x?: number;
@@ -456,8 +459,23 @@ export interface ImageInput {
   y?: number;
   /** Placement within the region box (default `center`). Ignored if x/y set. */
   corner?: ImageCorner;
-  /** Inset from the region edge for corner placement (default 8). */
+  /** Inset from the region edge for corner placement (default 8). Also `fit: "region"`'s box inset. */
   margin?: number;
+  /**
+   * Size the display box to fit inside the region's own box (aspect-preserving
+   * contain, inset by `margin`) instead of a caller-computed `width`/`height` —
+   * resolved in `page.ts:resolveImages` once the region's geometry and the
+   * image's intrinsic dimensions are both known. Mutually exclusive with
+   * `width`/`height`.
+   */
+  fit?: "region";
+  /**
+   * Downscale the source (PNG only) so neither dimension exceeds this, before
+   * sizing/hashing/writing — resolved in `page.ts:resolveImages`. Use instead of
+   * resizing a source image by hand before sending. A JPEG source over the limit
+   * still throws (only the PNG path decodes/re-encodes pixels).
+   */
+  maxDimension?: number;
   /** Image opacity, 0–1. */
   opacity?: number;
   /**

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -1357,6 +1357,78 @@ async function main() {
   check("a source over 1536px warns (image_dimensions_large, info)",
     bigDims.warningDetails.some((w) => w.code === "image_dimensions_large" && w.severity === "info"), JSON.stringify(bigDims.warningDetails));
 
+  console.log("\nimages[].fit:\"region\" + maxDimension (server-computed sizing / downscale)");
+  // fit:"region" sizes the display box from the region's own geometry (aspect-preserving
+  // contain, inset by margin) — derive the expected size from parsed geometry, not a
+  // hard-coded box, so the fixtures' template dims can keep changing.
+  const imgPageRead = await readPage(root, imgPage);
+  const todoGeo = imgPageRead.regions.find((r) => r.name === "todo")!;
+  const fitMargin = 8;
+  const fitBoxW = todoGeo.width! - fitMargin * 2;
+  const fitBoxH = todoGeo.height! - fitMargin * 2;
+  const fitScale = Math.min(fitBoxW / 40, fitBoxH / 20);
+  const expectedFitW = Math.round(40 * fitScale);
+  const expectedFitH = Math.round(20 * fitScale);
+  const fitSrc = encodePng({ width: 40, height: 20, pixels: new Uint8Array(40 * 20 * 4).fill(180) });
+  const fitResult = await writeUnderlay(root, imgPage, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "todo", images: [{ data: fitSrc.toString("base64"), format: "png", name: "fit-test", fit: "region" }] }],
+  });
+  const fitImgTag = fitResult.aiSvg?.match(/<image href="media\/ai\/fit-test\.png"[^/]*\/>/)?.[0] ?? "";
+  check(
+    "fit:\"region\" computes width/height from the region's own box (aspect-preserving contain)",
+    new RegExp(`width="${expectedFitW}" height="${expectedFitH}"`).test(fitImgTag),
+    fitImgTag,
+  );
+  let fitWidthConflict = false;
+  try {
+    await writeUnderlay(root, imgPage, {
+      status: "ready", dryRun: true,
+      regions: [{ region: "todo", images: [{ data: fitSrc.toString("base64"), format: "png", name: "fit-conflict", fit: "region", width: 100 }] }],
+    });
+  } catch { fitWidthConflict = true; }
+  check("fit:\"region\" + an explicit width errors clearly (mutually exclusive)", fitWidthConflict);
+
+  // maxDimension re-encodes the source at the smaller size (not just a display-box resize) —
+  // a real 100×10 PNG downscaled to fit 20px.
+  const bigSrc = encodePng({ width: 100, height: 10, pixels: new Uint8Array(100 * 10 * 4).fill(90) });
+  await writeUnderlay(root, imgPage, {
+    status: "ready",
+    regions: [{ region: "todo", images: [{ data: bigSrc.toString("base64"), format: "png", name: "downscaled", width: 100, maxDimension: 20 }] }],
+  });
+  const downscaledFile = path.join(root, imgPage, "media", "ai", "downscaled.png");
+  const downscaledDecoded = decodePng(await fs.readFile(downscaledFile));
+  check(
+    "maxDimension re-encodes the source file itself at the smaller size (100×10 → 20×2)",
+    downscaledDecoded.width === 20 && downscaledDecoded.height === 2,
+    `${downscaledDecoded.width}x${downscaledDecoded.height}`,
+  );
+  const downscaledWrite = await writeUnderlay(root, imgPage, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "todo", images: [{ data: bigSrc.toString("base64"), format: "png", name: "downscaled", width: 100, maxDimension: 20 }] }],
+  });
+  check(
+    "maxDimension downscale surfaces an info warning",
+    downscaledWrite.warningDetails.some((w) => w.code === "image_downscaled" && w.severity === "info"),
+    JSON.stringify(downscaledWrite.warningDetails),
+  );
+
+  // A JPEG source over maxDimension can't be resampled (no JPEG decoder in png.ts) — a clear
+  // error, not a silent no-op. Minimal real SOF0 header: 100×100.
+  const jpegSOF = Buffer.from([0xff, 0xd8, 0xff, 0xc0, 0x00, 0x0b, 0x08, 0x00, 0x64, 0x00, 0x64, 0x01, 0x01, 0x11, 0x00]);
+  let jpegMaxDimErr = "";
+  try {
+    await writeUnderlay(root, imgPage, {
+      status: "ready", dryRun: true,
+      regions: [{ region: "todo", images: [{ data: jpegSOF.toString("base64"), format: "jpeg", name: "jpeg-big", width: 40, maxDimension: 50 }] }],
+    });
+  } catch (e: any) { jpegMaxDimErr = e.message; }
+  check(
+    "a JPEG over maxDimension errors clearly instead of silently skipping the downscale",
+    /maxDimension downscale only supports PNG/.test(jpegMaxDimErr),
+    jpegMaxDimErr,
+  );
+
   console.log("\nraw svg size guard");
   const hugeRaw = await writeUnderlay(root, daily, {
     status: "ready", dryRun: true,


### PR DESCRIPTION
## Summary
- `images[].fit: "region"` — sizes the display box to fit inside the region's own box (aspect-preserving contain, inset by `margin`), so callers stop hand-computing a `width` from `read_page` geometry. Mutually exclusive with `width`/`height`.
- `images[].maxDimension` — downscales an over-large PNG source (re-encoding the actual bytes via a new box-filter resample in `png.ts`) instead of throwing/warning. JPEG sources over the limit still throw a clear error (no JPEG decoder in this codebase's minimal PNG-only codec).
- New `image_downscaled` info warning reports before/after dimensions.
- `write_underlay` now parses template geometry before resolving images (previously after), since `fit: "region"` needs region box lookups by name.

Closes #8.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run smoke` — 269/269 passing, including new coverage: `fit: "region"`'s computed size (derived from parsed geometry), the `fit`+explicit-`width` mutual-exclusion error, a real PNG resampled and re-written smaller on disk, the `image_downscaled` warning, and the JPEG+`maxDimension` error