### PR TITLE
Region recommended-image-size signal (imageFloor) (#10)

### DIFF
--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -257,8 +257,10 @@ shrink it, move it into an `ai` region, or drop it, rather than forcing it. Sizi
 heed the same way: **`image_aspect_mismatch`** (you passed a `height` off the source aspect —
 the renderer scales to the exact box, so it *will* stretch; omit `height` to aspect-fill),
 **`image_small_for_region`** (a sticker shrunk deep into a big box — fine for a corner accent,
-useless for something the user interacts with, like a habits tracker they pencil-check), and
-**`image_dimensions_large`** (source over the ~1536px guideline — downscale before sending). `notes` is
+useless for something the user interacts with, like a habit tracker they pencil-check — check a
+region's `imageFloor` from `read_page` *before* choosing a size, instead of iterating on the
+warning), and **`image_dimensions_large`** (source over the ~1536px guideline — downscale before
+sending, or set `images[].maxDimension`). `notes` is
 `fill: ink` (handwriting) — at most a *tiny* corner mark there, never a sticker over the writing
 area.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,31 @@ roadmap holds only planned feature development (bugs/polish live on the
 
 ---
 
+## Region recommended-image-size signal (`imageFloor`) — 2026-07-09
+
+Closes [#10](https://github.com/bsitkoff/onion_planner_mcp/issues/10). The `image_small_for_region`
+warning used a generic 35%-of-box heuristic because the server had no notion of what an image
+*in this region* actually needs — the habits-tracker case (~245px tall so the checkboxes stay
+pencil-checkable) lived only in skill prose. Implemented the server-side per-intent heuristic
+(no app/template-contract coupling, unlike the declared `data-*` alternative also sketched in
+the issue):
+
+- `svg.ts`'s new `imageSizeFloor(region)` returns a declared 245×245 floor when a region's own
+  `intent` marks it interactive (matches `/\bhabit\b/i` — the one recurring case the shipped
+  catalogue documents, e.g. ainotes' "a habit sticker or small image"), else the previous
+  35%-of-box heuristic. One function backs both the warning and the new signal, so they can't
+  drift.
+- `read_page`'s regions gain `imageFloor: {width, height, interactive} | null` — the same floor
+  a write will warn against, so a caller can size an image right the first time instead of
+  iterating on `image_small_for_region`.
+- `docs/AUTHORING.md` points at `imageFloor` instead of the hand-maintained "~245px" note.
+- `test/smoke.ts`: `imageFloor` on an interactive region (ainotes) vs a non-interactive one
+  (todo) parsed from geometry; a 150×150 image that clears the old 35%-of-box heuristic in
+  ainotes' box but still trips the declared 245px floor, and the same size staying quiet in a
+  non-interactive region. 268/268 passing · tsc clean.
+
+---
+
 ## Washi-tape blocks widened + long labels wrap — 2026-07-06
 
 The schedule's washi-tape duration block was subtracting its wide *left* gutter (reserved for

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -83,9 +83,11 @@ nightly/morning runs:
 3. **Expose the template's printed text via `read_page`** — so an orchestrator can see that
    the template already prints the date/labels instead of memorizing "don't double-write the
    date" in skill prose. [#9](https://github.com/bsitkoff/onion_planner_mcp/issues/9)
-4. **Region recommended-image-size signal** — replace the 35%-of-box heuristic behind
-   `image_small_for_region` with a declared floor (template `data-*` key or per-intent
-   default). [#10](https://github.com/bsitkoff/onion_planner_mcp/issues/10)
+
+**Shipped 2026-07-09:** region recommended-image-size signal — `read_page`'s `imageFloor`
+replaces the 35%-of-box heuristic behind `image_small_for_region` with a declared per-intent
+floor (245×245 for an interactive region like a habit tracker) —
+[#10](https://github.com/bsitkoff/onion_planner_mcp/issues/10); see `CHANGELOG.md`.
 
 ## Planned — blocked on the app
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,11 @@ server.tool(
   "read_page",
   "Read one shared page: its manifest, parsed regions (name, x, y, width, height, rows, " +
     "cols, startHour/rowsPerHour for timed grids, a `list` bucket, absolute ruled-line " +
-    "positions, a `fill`, a free-text `intent`, and `labelFilled` — whether a region's " +
+    "positions, a `fill`, a free-text `intent`, `imageFloor` — the {width,height} a centered " +
+    "image below trips `image_small_for_region` in this region (245×245 when `intent` marks " +
+    "it interactive, e.g. a habit tracker the user pencil-checks; else 35% of the box), so " +
+    "you can size an image right the first time instead of iterating on the warning — and " +
+    "`labelFilled` — whether a region's " +
     "printed label slot, if it has one, actually has a label banner drawn into it yet " +
     "(null if the region has no slot; false means the template prints a slot but nothing's " +
     "there — don't assume a slot means content exists, pass `label` to fill it)), current ai.svg, " +

--- a/src/page.ts
+++ b/src/page.ts
@@ -18,6 +18,7 @@ import {
   mergeRegions,
   emptySvg,
   imageDims,
+  imageSizeFloor,
   scanRawSvgElements,
   scanRawSvgDataUriImages,
   extractRegionGroups,
@@ -598,7 +599,16 @@ function pageSize(manifest: Manifest, templateSvg: string | null): [number, numb
  * slot but the current ai.svg doesn't draw a label banner into it (no ai.svg yet,
  * region never written, or written without `label`); `true` = it does.
  */
-export type RegionRead = Region & { labelFilled: boolean | null };
+export type RegionRead = Region & {
+  labelFilled: boolean | null;
+  /**
+   * The size `image_small_for_region` warns a centered image below in this region —
+   * computed by the exact `imageSizeFloor` a write later checks against, so the
+   * advertised and enforced floors can't drift (same pattern as `PageRead.theme`'s
+   * `underlay` palette). `null` when the region has no box to scale against.
+   */
+  imageFloor: { width: number; height: number; interactive: boolean } | null;
+};
 
 export interface PageRead {
   page: string;
@@ -650,6 +660,7 @@ export async function readPage(
   const regionsOut: RegionRead[] = regions.map((r) => ({
     ...r,
     labelFilled: r.labelSlot === null ? null : /letter-spacing="0\.1em"/.test(aiGroups.get(r.name) ?? ""),
+    imageFloor: imageSizeFloor(r),
   }));
   return {
     page: rel,

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -815,6 +815,34 @@ export function imageDims(buf: Uint8Array, format: "png" | "jpeg"): ImageDims {
   throw new Error("could not read JPEG dimensions.");
 }
 
+/**
+ * A region an image floats small in stops working when the user physically interacts
+ * with it — pencil-checking a habit tracker needs real size no matter how big the box
+ * is, unlike a decorative accent that can legitimately stay tiny. Detected from the
+ * region's own `intent` rather than a hard-coded region name (a template's `intent` is
+ * free text, but "habit" is the one recurring case the shipped catalogue documents).
+ */
+const INTERACTIVE_IMAGE_FLOOR = 245; // px — pencil-checkable habit-tracker guideline
+const INTERACTIVE_INTENT_RE = /\bhabit\b/i;
+
+/**
+ * The size `image_small_for_region` warns below for a centered image in this region —
+ * a declared floor (245px, both dimensions) for a region whose `intent` marks it
+ * interactive, else the default 35%-of-box heuristic. Exported so `read_page` can
+ * advertise the same floor a write will warn against (page.ts), computed by this one
+ * function so the advertised and enforced floors can't drift. `null` when the region
+ * has no box to scale against.
+ */
+export function imageSizeFloor(
+  region: Region,
+): { width: number; height: number; interactive: boolean } | null {
+  if (region.width === null || region.height === null) return null;
+  if (region.intent && INTERACTIVE_INTENT_RE.test(region.intent)) {
+    return { width: INTERACTIVE_IMAGE_FLOOR, height: INTERACTIVE_IMAGE_FLOOR, interactive: true };
+  }
+  return { width: region.width * 0.35, height: region.height * 0.35, interactive: false };
+}
+
 /** An axis-aligned rectangle, for overlap tests. */
 interface Bbox {
   x: number;
@@ -1226,19 +1254,16 @@ export function composeAiSvg(
       // as a deliberate small accent and stays quiet.
       const centered =
         img.x === undefined && img.y === undefined && (img.corner === undefined || img.corner === "center");
-      if (
-        centered &&
-        region.width !== null &&
-        region.height !== null &&
-        img.width < region.width * 0.35 &&
-        img.height < region.height * 0.35
-      ) {
+      const floor = imageSizeFloor(region);
+      if (centered && floor && img.width < floor.width && img.height < floor.height) {
+        const guidance = floor.interactive
+          ? `content the user interacts with (a habit tracker) needs real size (~${INTERACTIVE_IMAGE_FLOOR}px tall to pencil-check)`
+          : "size it toward the box, or corner-place it if it's meant as a small accent";
         warn(
           "image_small_for_region",
           `region "${region.name}": image (${img.width}×${img.height}) floats small in the ` +
-            `middle of the ${region.width}×${region.height} box — size it toward the box, or ` +
-            `corner-place it if it's meant as a small accent. Content the user interacts with ` +
-            `(a habits tracker) needs real size (~245px tall to pencil-check).`,
+            `middle of the ${region.width}×${region.height} box — floor is ` +
+            `${Math.round(floor.width)}×${Math.round(floor.height)}; ${guidance}.`,
           "info",
           region.name,
         );

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -141,6 +141,21 @@ async function main() {
   check("schedule region parsed with ruled lines", (schedule?.ruledLines.length ?? 0) >= 8, String(schedule?.ruledLines.length));
   check("ainotes region parsed (no-ruled box)", !!ainotes && ainotes.ruledLines.length === 0, String(ainotes?.ruledLines.length));
   check("todo region parsed", !!todo);
+  // imageFloor: ainotes' own intent mentions "a habit sticker" — the interactive floor
+  // (245×245) applies regardless of the box size; todo's intent doesn't, so it gets the
+  // default 35%-of-box heuristic instead.
+  check(
+    "ainotes' intent marks it interactive -> a 245×245 imageFloor",
+    ainotes?.imageFloor?.interactive === true && ainotes.imageFloor.width === 245 && ainotes.imageFloor.height === 245,
+    JSON.stringify(ainotes?.imageFloor),
+  );
+  check(
+    "todo's intent (task checkbox rows, not an image) -> the default 35%-of-box floor",
+    todo?.imageFloor?.interactive === false &&
+      todo?.width !== null && todo.imageFloor?.width === todo.width * 0.35 &&
+      todo?.height !== null && todo.imageFloor?.height === todo.height * 0.35,
+    JSON.stringify({ imageFloor: todo?.imageFloor, box: [todo?.width, todo?.height] }),
+  );
   // The template prints a dashed label slot nested in schedule's own <g> — parseRegions
   // must surface it (Region.labelSlot) without confusing it for the region's own box.
   check("schedule region exposes its printed label slot", !!schedule?.labelSlot, JSON.stringify(schedule?.labelSlot));
@@ -1335,6 +1350,30 @@ async function main() {
     floating.warningDetails.some((w) => w.code === "image_small_for_region" && w.severity === "info"), JSON.stringify(floating.warningDetails));
   check("the same tiny image corner-placed stays quiet (deliberate accent)",
     !cleanImg.warningDetails.some((w) => w.code === "image_small_for_region"), JSON.stringify(cleanImg.warningDetails));
+  // ainotes' box is 289×422 — the old 35%-of-box heuristic (~101×148) would NOT have
+  // flagged a 150×150 centered image, but its intent ("a habit sticker") now carries the
+  // declared 245×245 interactive floor, which does.
+  const habitSized = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "ainotes", images: [{ data: PNG_1x1, format: "png", name: "habit", width: 150, height: 150, corner: "center" }] }],
+  });
+  check(
+    "a habit-tracker-sized image below the 245px interactive floor still warns, even though it clears the old 35%-of-box heuristic",
+    habitSized.warningDetails.some((w) => w.code === "image_small_for_region" && /floor is 245×245/.test(w.message)),
+    JSON.stringify(habitSized.warningDetails),
+  );
+  // The same 150×150 in todo (no "habit" intent) stays under the default 35% heuristic —
+  // todo's box (289×902) puts the width floor at ~101px, which 150 clears (the warning
+  // needs BOTH dimensions below floor), so it stays quiet.
+  const nonHabitSized = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "todo", images: [{ data: PNG_1x1, format: "png", name: "not-habit", width: 150, height: 150, corner: "center" }] }],
+  });
+  check(
+    "the same size in a non-interactive region uses the default heuristic, not the 245px floor",
+    !nonHabitSized.warningDetails.some((w) => w.code === "image_small_for_region"),
+    JSON.stringify(nonHabitSized.warningDetails),
+  );
   // A source over the 1536px guideline (IHDR-only fake; dims read from the header) → info warning.
   const fakeBigPng = (() => {
     const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);


### PR DESCRIPTION
## Summary
- `svg.ts`'s new `imageSizeFloor(region)` returns a declared 245×245 floor for a region whose `intent` marks it interactive (matches `/\bhabit\b/i` — e.g. ainotes' "a habit sticker or small image"), else the previous 35%-of-box heuristic. One function backs both the `image_small_for_region` warning and the new signal, so they can't drift.
- `read_page`'s regions gain `imageFloor: {width, height, interactive} | null` so a caller can size an image right the first time instead of iterating on the warning.
- `docs/AUTHORING.md` points at `imageFloor` instead of the hand-maintained "~245px" note.

Implements the issue's app-decoupled alternative (a server-side per-intent heuristic) rather than a new template `data-*` attribute, which would need cross-repo registration in the Onionskin app's `FORMAT.md` — out of scope for this repo alone.

Closes #10.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run smoke` — 268/268 passing, including new coverage: `imageFloor` on an interactive region (ainotes) vs a non-interactive one (todo), and a 150×150 image that clears the old 35%-of-box heuristic in ainotes' box but still trips the declared 245px floor