### PR TITLE
Header art-slot image sizing (#45) + dangling image-href warning (#46)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,10 +148,18 @@ server has no network/generation. The app's renderer resolves `<image href>` onl
 **page-relative file path** (no data-URIs), so `page.ts:resolveImages` validates the bytes
 (magic vs `format`, 2MB cap), writes them to the page's **`media/ai/`** folder, and rewrites
 the `<image href="media/ai/…">` into the region group; `svg.ts:imageDims` reads intrinsic size
-(aspect-fills an omitted height). Placement is region-local via `corner`/`x`/`y`. After each
-write, `gcOrphanMedia` deletes any `media/ai/*` the final (post-merge) ai.svg no longer
-references; `clear_underlay` removes the folder. Images ride inside their region's `<g>`, so
-`merge` preserves them with the region.
+(aspect-fills an omitted height). Placement is region-local via `corner`/`x`/`y`. When a
+region prints a dashed illustration placeholder (a rounded `stroke-dasharray` rect with no
+`data-region` — the header's right-side banner box), `template.parseRegions` exposes it as
+`Region.artSlot` and `svg.imageBox` makes it the effective box for image `corner`/`fit`
+placement **and** the `imageFloor` (so a right-sized header banner lands in the box, covering
+the placeholder, and isn't flagged too-small against the full band — #45). Text placement
+still uses the full region box. After each write, `gcOrphanMedia` deletes any `media/ai/*`
+the final (post-merge) ai.svg no longer references, and `validateImageHrefs` warns
+`image_href_missing` for any `<image href="media/ai/…">` in the final svg with no file written
+or on disk (a stale name, or a raw-svg href whose bytes weren't supplied — #46);
+`clear_underlay` removes the folder. Images ride inside their region's `<g>`, so `merge`
+preserves them with the region.
 
 A region entry may instead carry a **`calendar`** spec (`{ month: "YYYY-MM", days?: [...] }`)
 in place of `lines` — used for the gridded `month` region. `svg.composeCalendar` derives each

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -344,6 +344,27 @@ sending, or set `images[].maxDimension`). `notes` is
 `fill: ink` (handwriting) — at most a *tiny* corner mark there, never a sticker over the writing
 area.
 
+**A header banner goes in the header's art slot — let the server place it.** The daily
+templates print a dashed rounded box on the right of the `header` band as the banner-art
+drop-zone; `read_page` surfaces it as the region's **`artSlot`** ({x,y,width,height}, or null
+on templates with no such box — agenda/monthly/todo/reflection/blank). You don't compute
+coordinates for it: give the `header` region an `images` entry and the server places it *in the
+art slot* — `corner`/`fit: "region"` and the `imageFloor` all target the slot, not the full
+band. So `fit: "region"` fills the box (covering the dashed placeholder — otherwise it renders
+as an orphaned empty box under your banner), and a plain `width` with no `x`/`y` centers it in
+the slot. Don't invent an aspect requirement or stretch art to fill the band: omit `height` to
+keep native proportions — whitespace inside the slot is fine. The date/title text still lands
+in the full header band, clear of the art slot.
+
+**Filenames must resolve — a dangling `href` renders blank.** The server writes each image to
+`media/ai/<stem>.<ext>` (the `stem` is `images[].name` if you pass one, else a content hash) and
+rewrites the `<image href>` for you — so with the structured `images` array you never author an
+href by hand. If you *do* hand-write an `<image href="media/ai/…">` in a raw region `svg`, or
+reuse a stale filename across an update, the server now warns **`image_href_missing`** when the
+final `ai.svg` references a `media/ai/` file that wasn't written this call and isn't on disk (it
+would render blank on device). The fix is always to supply the bytes through `images` and let
+the server own the filename, not to guess a stem.
+
 **The sourcing recipe (generate the image however you like, land it on the Mac, embed by path):**
 
 1. Generate a small square image with whatever image tool you use. Prompt for the planner

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,36 @@ roadmap holds only planned feature development (bugs/polish live on the
 
 ---
 
+## Fix: header images size/place against the illustration sub-box, not the full band — 2026-08-20
+
+[#45](https://github.com/bsitkoff/onion_planner_mcp/issues/45). A daily `header` group ships a
+second, untagged dashed `<rect>` — the banner-art drop-zone (e.g. 300×104 at the band's right) —
+but `parseRegions` kept only the first non-`label-` rect and dropped it. So image floors and
+`fit: "region"` measured against the full 912×116 band: a correctly-sized ~300px banner was
+flagged `image_small_for_region`, `fit: "region"` spanned the date text, and the dashed box was
+left empty (the orphaned box in [#25](https://github.com/bsitkoff/onion_planner_mcp/issues/25)).
+
+- **`template.parseRegions` now surfaces `Region.artSlot`** — a dashed, `data-region`-less rect,
+  detected by its `stroke-dasharray` (distinct from the box and any `label-*` slot). null on
+  templates with no such placeholder (agenda/monthly/todo/reflection/blank headers).
+- **`svg.imageBox` makes the art slot the effective box for images** — `corner`/`fit: "region"`
+  placement and `imageSizeFloor` all target it, so a header banner lands in the box (covering the
+  placeholder) and a right-sized banner isn't flagged too-small. Text placement still uses the
+  full region box. `read_page` advertises `artSlot` + the slot-scaled `imageFloor`.
+- Needs [onionskin#224](https://github.com/bsitkoff/onionskin/issues/224) for the clean,
+  app-tagged art rect + composer/template reconciliation; this ships the interim heuristic.
+
+## Fix: a dangling `<image href>` now warns instead of rendering blank — 2026-08-20
+
+[#46](https://github.com/bsitkoff/onion_planner_mcp/issues/46). A raw-svg `<image href="media/ai/…">`
+pointing at a file that was never written (a stale filename, or bytes not supplied through
+`images`) passed through unchecked and rendered blank on device — the real "stale filenames"
+failure. `page.ts:validateImageHrefs` now scans the final `ai.svg` and warns
+**`image_href_missing`** for any `media/ai/` reference with no file written this call or on disk
+(covers the raw-svg and post-merge paths; structured images set their own href and never
+false-warn). Docs (`AUTHORING.md`) now spell out the `name`-stem contract: supply bytes through
+`images` and let the server own the filename.
+
 ## Fix: a `showHours`-only region no longer trips a false `empty_region` — 2026-07-24
 
 [#38](https://github.com/bsitkoff/onion_planner_mcp/issues/38). `showHours: true` on its own is

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,9 +146,13 @@ server.tool(
     "a weekday header, hour-line numbers), in document order, empty if the template prints " +
     "nothing here; check it before writing a line so you don't double-write content the " +
     "template already shows (e.g. the date under a template that already prints \"TODAY\"), " +
+    "`artSlot` — a printed dashed illustration drop-zone nested in the region (e.g. the " +
+    "header's right-side banner box), region-local {x,y,width,height} or null; when present, " +
+    "image placement (corner/fit) and sizing target it, not the full region box, " +
     "`imageFloor` — the {width,height} a centered image below trips `image_small_for_region` " +
     "in this region (245×245 when `intent` marks it interactive, e.g. a habit tracker the " +
-    "user pencil-checks; else 35% of the box), so you can size an image right the first time " +
+    "user pencil-checks; else 35% of the box, or of the `artSlot` when it has one), so you " +
+    "can size an image right the first time " +
     "instead of iterating on the warning — and `labelFilled` — whether a region's " +
     "printed label slot, if it has one, actually has a label banner drawn into it yet " +
     "(null if the region has no slot; false means the template prints a slot but nothing's " +

--- a/src/page.ts
+++ b/src/page.ts
@@ -20,6 +20,7 @@ import {
   emptySvg,
   imageDims,
   imageSizeFloor,
+  imageBox,
   scanRawSvgElements,
   scanRawSvgDataUriImages,
   extractRegionGroups,
@@ -659,13 +660,18 @@ async function resolveImages(
               `— no box geometry found for "${region.region}".`,
           );
         }
+        // Fit into the region's image box — the art slot (e.g. the header's banner box)
+        // when present, else the full region box (#45).
+        const fitBox = imageBox(geo);
+        const bw = fitBox.width ?? geo.width;
+        const bh = fitBox.height ?? geo.height;
         const margin = img.margin ?? 8;
-        const boxW = geo.width - margin * 2;
-        const boxH = geo.height - margin * 2;
+        const boxW = bw - margin * 2;
+        const boxH = bh - margin * 2;
         if (boxW <= 0 || boxH <= 0) {
           throw new Error(
             `image in region "${region.region}": fit:"region" box is too small for margin ` +
-              `${margin} (region box is ${geo.width}×${geo.height}).`,
+              `${margin} (image box is ${bw}×${bh}).`,
           );
         }
         const scale = Math.min(boxW / dims.width, boxH / dims.height);
@@ -739,6 +745,38 @@ async function gcOrphanMedia(pageAbs: string, svg: string): Promise<void> {
       await fs.rm(path.join(mediaAiAbs, f), { force: true }).catch(() => {});
     }
   }
+}
+
+/**
+ * Every `<image href="media/ai/…">` in the final ai.svg must resolve to a file written
+ * this call or already on disk — otherwise the app renders it blank (the renderer only
+ * resolves a page-relative path). Catches a stale filename or a raw-svg `<image href>`
+ * whose bytes were never supplied through `images`. Warns per dangling reference. See #46.
+ */
+async function validateImageHrefs(
+  pageAbs: string,
+  svg: string,
+  resolvedFiles: Set<string>,
+): Promise<WarningDetail[]> {
+  const refs = new Set([...svg.matchAll(/href="media\/ai\/([^"]+)"/g)].map((m) => m[1]));
+  if (refs.size === 0) return [];
+  let onDisk = new Set<string>();
+  try {
+    onDisk = new Set(await fs.readdir(path.join(pageAbs, MEDIA_AI)));
+  } catch {
+    // no media/ai folder → nothing on disk; every ref is dangling
+  }
+  const details: WarningDetail[] = [];
+  for (const f of refs) {
+    if (!resolvedFiles.has(f) && !onDisk.has(f)) {
+      const message =
+        `ai.svg references media/ai/${f}, but no such image was written this call or found ` +
+        `on disk — it will render blank on device (a stale filename, or a raw-svg ` +
+        "`<image href>` whose bytes weren't supplied through `images`?).";
+      details.push({ code: "image_href_missing", severity: "warning", message });
+    }
+  }
+  return details;
 }
 
 async function readJson<T>(absFile: string): Promise<T> {
@@ -1089,6 +1127,20 @@ export async function writeUnderlay(
     }
   } else {
     throw new Error("writeUnderlay requires either `svg` or `regions`.");
+  }
+
+  // Every media/ai href in the final svg must resolve to a real file (#46) — a dangling
+  // ref (stale name, or a raw-svg href with no supplied bytes) renders blank on device.
+  const resolvedFiles = new Set<string>();
+  for (const r of opts.regions ?? []) {
+    for (const im of r.images ?? []) {
+      if (im.href) resolvedFiles.add(im.href.replace(/^media\/ai\//, ""));
+    }
+  }
+  const hrefDetails = await validateImageHrefs(abs, svg, resolvedFiles);
+  if (hrefDetails.length) {
+    warnings.push(...hrefDetails.map((d) => d.message));
+    warningDetails.push(...hrefDetails);
   }
 
   const bytes = Buffer.byteLength(svg);

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -949,11 +949,25 @@ const INTERACTIVE_INTENT_RE = /\bhabit\b/i;
 export function imageSizeFloor(
   region: Region,
 ): { width: number; height: number; interactive: boolean } | null {
-  if (region.width === null || region.height === null) return null;
+  const box = imageBox(region);
+  if (box.width === null || box.height === null) return null;
   if (region.intent && INTERACTIVE_INTENT_RE.test(region.intent)) {
     return { width: INTERACTIVE_IMAGE_FLOOR, height: INTERACTIVE_IMAGE_FLOOR, interactive: true };
   }
-  return { width: region.width * 0.35, height: region.height * 0.35, interactive: false };
+  return { width: box.width * 0.35, height: box.height * 0.35, interactive: false };
+}
+
+/**
+ * The effective box for placing / sizing an *image* in a region: the region's `artSlot`
+ * (a printed illustration placeholder, e.g. the header's right-side banner box) when one
+ * exists, else the region's own box. Region-local coords. Only images target the art
+ * slot — text placement always uses the full region box. See #45.
+ */
+export function imageBox(
+  region: Region,
+): { x: number; y: number; width: number | null; height: number | null } {
+  if (region.artSlot) return { ...region.artSlot };
+  return { x: 0, y: 0, width: region.width, height: region.height };
 }
 
 /** An axis-aligned rectangle, for overlap tests. */
@@ -969,29 +983,35 @@ function bboxesOverlap(a: Bbox, b: Bbox): boolean {
   return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
 }
 
-/** Region-local placement of an image from its corner/margin (or explicit x/y). */
+/**
+ * Region-local placement of an image from its corner/margin (or explicit x/y). Corner
+ * placement resolves within the region's image box — the `artSlot` when present (so a
+ * header banner lands in its illustration box, covering the dashed placeholder), else
+ * the full region box. Explicit x/y stay verbatim region-local, unchanged. See #45.
+ */
 function placeImage(region: Region, img: ImageInput): { x: number; y: number } {
   if (img.x !== undefined || img.y !== undefined) {
     return { x: Math.round(img.x ?? 0), y: Math.round(img.y ?? 0) };
   }
+  const box = imageBox(region);
   const margin = img.margin ?? 8;
-  const W = region.width;
-  const H = region.height;
+  const W = box.width;
+  const H = box.height;
   const w = img.width ?? 0;
   const h = img.height ?? 0;
-  if (W === null || H === null) return { x: margin, y: margin }; // no box → top-left inset
+  if (W === null || H === null) return { x: box.x + margin, y: box.y + margin }; // no box → top-left inset
   switch (img.corner ?? "center") {
     case "top-left":
-      return { x: margin, y: margin };
+      return { x: box.x + margin, y: box.y + margin };
     case "top-right":
-      return { x: Math.round(W - w - margin), y: margin };
+      return { x: Math.round(box.x + W - w - margin), y: box.y + margin };
     case "bottom-left":
-      return { x: margin, y: Math.round(H - h - margin) };
+      return { x: box.x + margin, y: Math.round(box.y + H - h - margin) };
     case "bottom-right":
-      return { x: Math.round(W - w - margin), y: Math.round(H - h - margin) };
+      return { x: Math.round(box.x + W - w - margin), y: Math.round(box.y + H - h - margin) };
     case "center":
     default:
-      return { x: Math.round((W - w) / 2), y: Math.round((H - h) / 2) };
+      return { x: Math.round(box.x + (W - w) / 2), y: Math.round(box.y + (H - h) / 2) };
   }
 }
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -61,6 +61,15 @@ export interface Region {
    */
   labelSlot: { x: number; y: number; width: number; height: number } | null;
   /**
+   * The template's printed dashed *illustration* rect nested in this region's own <g>
+   * (a rounded `stroke-dasharray` placeholder carrying no `data-region`) — the intended
+   * drop-zone for AI banner art (e.g. the header's right-side banner box). Region-local
+   * coords, same convention as `labelSlot`. null when the region prints no art
+   * placeholder. When present, image sizing / placement / floors target this slot
+   * instead of the full region box; text placement still uses the full box. See #45.
+   */
+  artSlot: { x: number; y: number; width: number; height: number } | null;
+  /**
    * Text the template itself already prints inside this region's `<g>` (a section
    * label like "Schedule", chrome like "TODAY"/"DATE", a weekday header, hour-line
    * numbers) — in document order. Empty when the template prints nothing here. Lets
@@ -356,6 +365,24 @@ export function parseRegions(templateSvg: string, templateName?: string): Region
           height: num(labelRect["@_height"]) ?? 0,
         }
       : null;
+    // A dashed rect with no `data-region` (distinct from the box and any label slot) is
+    // the region's illustration placeholder — the AI banner-art drop-zone (#45).
+    // Detected by its `stroke-dasharray` so it's never confused with the region's box.
+    const artRect = rects.find(
+      (r) =>
+        r !== labelRect &&
+        r !== rect &&
+        typeof r["@_stroke-dasharray"] === "string" &&
+        r["@_stroke-dasharray"].trim() !== "",
+    );
+    const artSlot = artRect
+      ? {
+          x: num(artRect["@_x"]) ?? 0,
+          y: num(artRect["@_y"]) ?? 0,
+          width: num(artRect["@_width"]) ?? 0,
+          height: num(artRect["@_height"]) ?? 0,
+        }
+      : null;
 
     const lines: any[] = Array.isArray(g.line) ? g.line : g.line ? [g.line] : [];
     const ruledLines: number[] = [];
@@ -405,6 +432,7 @@ export function parseRegions(templateSvg: string, templateName?: string): Region
       ruledLines,
       colLines,
       labelSlot,
+      artSlot,
       printedText,
     });
   }

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -180,6 +180,17 @@ async function main() {
   // header's dashed art-banner rect has no data-region, so it's NOT a label slot.
   const header = read.regions.find((r) => r.name === "header");
   check("header's decorative dashed rect (no data-region) is not read as a label slot", header?.labelSlot === null, JSON.stringify(header?.labelSlot));
+  // #45: the dashed illustration rect IS surfaced as `artSlot` — the intended image
+  // drop-zone — so image sizing/floors target it, not the full header band.
+  check("header exposes its dashed illustration rect as artSlot", !!header?.artSlot && header.artSlot.width === 300 && header.artSlot.height === 104, JSON.stringify(header?.artSlot));
+  check("header artSlot is offset to the right of the header box (x=612, y=6)", header?.artSlot?.x === 612 && header?.artSlot?.y === 6, JSON.stringify(header?.artSlot));
+  // The floor scales off the art slot (35% of 300×104), NOT the full 912×116 band — so a
+  // right-sized ~300px banner is no longer flagged too-small.
+  check("header imageFloor scales off the art slot, not the full header band", header?.imageFloor?.width === 300 * 0.35 && header?.imageFloor?.height === 104 * 0.35, JSON.stringify({ floor: header?.imageFloor, box: [header?.width, header?.height], art: header?.artSlot }));
+  // A header with no illustration rect (agenda/monthly/todo/reflection/blank) → artSlot null.
+  const agendaHeaderSvg = await fs.readFile(path.join(root, "Templates", "agenda-minimal", "template.svg"), "utf8");
+  const agendaHeader = parseRegions(agendaHeaderSvg, "agenda-minimal").find((r) => r.name === "header");
+  check("a header with no illustration rect has artSlot === null", agendaHeader?.artSlot === null, JSON.stringify(agendaHeader?.artSlot));
   // printedText: the template's own <text> content per region — lets an orchestrator
   // see that daily-minimal's header already prints "TODAY" chrome instead of relying
   // on memorized per-template knowledge (the #9 double-date-write bug).
@@ -1410,6 +1421,29 @@ async function main() {
   const travBase = travHref.replace(/^href="media\/ai\//, "").replace(/"$/, "");
   // Safe = stays under media/ai/: no slash in the filename, no leading dot (no `../`).
   check("sanitizes a traversal filename", travHref.startsWith('href="media/ai/') && !travBase.includes("/") && !travBase.startsWith("."), travHref);
+
+  // #45 header art slot end-to-end + #46 href validation.
+  console.log("\nheader image lands in the art slot (#45); dangling hrefs warn (#46)");
+  const hdrPage = "Shared/Daily/2026-06-28";
+  await createPage(root, { chapter: "Daily", name: "2026-06-28", title: "Header test", template: "daily-minimal" });
+  // A header image with no explicit x/y lands INSIDE the art slot (region-local x ≥ 612),
+  // covering the dashed placeholder instead of floating at header-left (issue #25).
+  await writeUnderlay(root, hdrPage, { status: "ready", regions: [{ region: "header", images: [{ data: PNG_1x1, format: "png", name: "banner", width: 120 }] }] });
+  const hdrAi = await fs.readFile(path.join(root, hdrPage, "ai.svg"), "utf8");
+  const hdrImg = regionGroup(hdrAi, "header") ?? "";
+  const hdrX = Number(hdrImg.match(/<image[^>]*\bx="(-?\d+)"/)?.[1] ?? "-1");
+  check("header image is placed within the art slot (x ≥ 612)", hdrX >= 612, `x=${hdrX} :: ${hdrImg.slice(0, 220)}`);
+  // fit:"region" on the header contains into the art slot (≤ 300 wide), not the full band.
+  const fitHdr = await writeUnderlay(root, hdrPage, { status: "ready", dryRun: true, regions: [{ region: "header", images: [{ data: PNG_1x1, format: "png", name: "fit", fit: "region" }] }] });
+  const fitImg = regionGroup(fitHdr.aiSvg, "header") ?? "";
+  const fitW = Number(fitImg.match(/<image[^>]*\bwidth="(\d+)"/)?.[1] ?? "9999");
+  check("fit:\"region\" on the header contains into the art slot (width ≤ 300)", fitW <= 300, `w=${fitW} :: ${fitImg.slice(0, 220)}`);
+  // #46: a raw-svg <image href> to a media/ai file that was never written must warn.
+  const ghost = await writeUnderlay(root, hdrPage, { status: "ready", dryRun: true, regions: [{ region: "ainotes", svg: '<image href="media/ai/ghost.png" x="0" y="0" width="40" height="40"/>' }] });
+  check("dangling <image href> warns image_href_missing", ghost.warningDetails.some((w) => w.code === "image_href_missing"), JSON.stringify(ghost.warningDetails));
+  // A properly supplied structured image does NOT warn (no false positive).
+  const okHref = await writeUnderlay(root, hdrPage, { status: "ready", dryRun: true, regions: [{ region: "todo", images: [{ data: PNG_1x1, format: "png", name: "real", width: 40 }] }] });
+  check("a resolved structured image does not warn image_href_missing", !okHref.warningDetails.some((w) => w.code === "image_href_missing"), JSON.stringify(okHref.warningDetails));
 
   console.log("\nwrite_underlay images via local file `path` (no base64 through context)");
   const srcPng = path.join(os.tmpdir(), "onionskin-smoke-src.png");


### PR DESCRIPTION
Closes #45
Closes #46

Fixes the two header-image / "stale filename" pains from the 2026-08-20 cross-repo audit.

## #45 — header images size/place against the illustration sub-box, not the full band
A daily `header` group ships a second, untagged dashed `<rect>` (the banner-art drop-zone, e.g. 300×104 at the band's right), but `parseRegions` kept only the first non-`label-` rect and dropped it — so image floors and `fit:"region"` measured against the full 912×116 band. A right-sized ~300px banner got flagged `image_small_for_region`, `fit:"region"` spanned the date, and the dashed box was left empty (the orphaned box in #25).

- `template.parseRegions` now surfaces **`Region.artSlot`** — a dashed, `data-region`-less rect detected by `stroke-dasharray` (distinct from the box and any `label-*` slot). `null` on templates with no such placeholder (agenda/monthly/todo/reflection/blank headers).
- New **`svg.imageBox`** makes the art slot the effective box for image `corner`/`fit:"region"` placement **and** `imageSizeFloor`. A header banner lands in the box (covering the placeholder); a right-sized banner isn't flagged too-small. Text placement still uses the full region box.
- `read_page` advertises `artSlot` + the slot-scaled `imageFloor`.
- **Scope:** interim `stroke-dasharray` heuristic. The clean, app-tagged art rect + composer/template reconciliation is bsitkoff/onionskin#224.

## #46 — a dangling `<image href>` warns instead of rendering blank
A raw-svg `<image href="media/ai/…">` (or a stale filename across an update) pointing at a file never written passed through unchecked and rendered blank on device — the real "stale filenames" failure. `page.ts:validateImageHrefs` now scans the final `ai.svg` and warns **`image_href_missing`** for any `media/ai/` reference with no file written this call or on disk (raw-svg + post-merge paths; structured images never false-warn).

## Testing
Regression-test-first: 6 new smoke tests written failing, then made to pass. Full suite **357 passed, 0 failed**; `tsc --noEmit` clean; live CLI `read_page` confirms `artSlot` {612,6,300,104} + corrected `imageFloor` {105,36.4}. Docs updated: `CLAUDE.md`, `AUTHORING.md` (header-art placement + filename contract), `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEFvwptDc4jKCm5UXRK43k