### PR TITLE
fix: fractional time rows, row/overflow warnings, tagged art-header + hour gutter (#30 #31 #32 #45 #44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,9 +131,14 @@ default is a chapter's own ink palette, not a constraint — and the orchestrato
 coordinates; they reference a region name and a row index from
 `read_page`. An unknown region name throws (listing the valid ones). Raw `svg` bypasses all
 of this — full control, no geometry help. `composeAiSvg` returns `{ svg, warnings }`; the
-warnings flag likely overflow (text past the region rect, more lines than ruled rows, a
-wrapped block that overruns its row, a `time` that can't be anchored) and surface in the
-`write_underlay` result — important because overnight/unattended writes have no human watching.
+warnings flag likely overflow (text past the region's right edge or below its box —
+`text_below_region`; a `row` beyond the ruled grid — `row_out_of_range`, instead of silently
+folding onto the last rule; two different `lines[]` entries on one baseline — `row_collision`,
+where wrapped continuations of one entry never count; a wrapped block that overruns its row; a
+`time` that can't be anchored) and surface in the `write_underlay` result — important because
+overnight/unattended writes have no human watching. A clock `time` resolves to a **fractional**
+row (`13:30` on a 1-row-per-hour grid is row 6.5, interpolated between the rules — #32), for
+both plain lines and washi blocks; the one-interval minimum block height still applies.
 
 Two `write_underlay` modifiers: **`merge`** patches only the named regions into the
 existing `ai.svg` (parsing its `<g data-region>` blocks, replacing matches, keeping the rest
@@ -149,12 +154,19 @@ server has no network/generation. The app's renderer resolves `<image href>` onl
 (magic vs `format`, 2MB cap), writes them to the page's **`media/ai/`** folder, and rewrites
 the `<image href="media/ai/…">` into the region group; `svg.ts:imageDims` reads intrinsic size
 (aspect-fills an omitted height). Placement is region-local via `corner`/`x`/`y`. When a
-region prints a dashed illustration placeholder (a rounded `stroke-dasharray` rect with no
-`data-region` — the header's right-side banner box), `template.parseRegions` exposes it as
-`Region.artSlot` and `svg.imageBox` makes it the effective box for image `corner`/`fit`
-placement **and** the `imageFloor` (so a right-sized header banner lands in the box, covering
-the placeholder, and isn't flagged too-small against the full band — #45). Text placement
-still uses the full region box. After each write, `gcOrphanMedia` deletes any `media/ai/*`
+region prints an illustration placeholder — the header's right-side banner box, tagged
+`<rect data-region="art-header" data-fill="ai">` since app catalogue `14-art-header-region`
+(onionskin#224), or an untagged dashed `stroke-dasharray` rect on pages frozen from the older
+catalogue (the live library: the app never migrates a page that already has an underlay) —
+`template.parseRegions` exposes it as `Region.artSlot` (+ `artSlotName`, the tag or null) and
+`svg.imageBox` makes it the effective box for image `corner`/`fit` placement **and** the
+`imageFloor` (so a right-sized header banner lands in the box, covering the placeholder, and
+isn't flagged too-small against the full band — #45). The region's own box is the first rect
+with **no** `data-region`, never "the first rect". `art-header` is addressed through its
+parent `header`, not as a region of its own. Text placement still uses the full region box.
+A ruled region also carries `gutterX` — where its rules start (34 on the cozy/colorful
+schedule/agenda, which print an hour-label gutter; 0 on minimal) — and default text/block x
+never sits left of it (#44). After each write, `gcOrphanMedia` deletes any `media/ai/*`
 the final (post-merge) ai.svg no longer references, and `validateImageHrefs` warns
 `image_href_missing` for any `<image href="media/ai/…">` in the final svg with no file written
 or on disk (a stale name, or a raw-svg href whose bytes weren't supplied — #46);

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -208,6 +208,15 @@ boxes, so when a word is later added or the text is edited, nothing reflows — 
 or leave holes. Separate entries are for separate *things* (each to-do, each event), not for
 the visual lines of one thing.
 
+**Row discipline: wrapping is fine, collisions are not.** One *logical item* per visual slot.
+A paragraph, a to-do, or a block label may wrap onto several lines and still read as one item —
+that's expected and never warned. What the server does warn about is two *different* entries
+landing in one slot: `row_collision` (two `lines[]` entries resolve to the same baseline — e.g.
+a `time` line on the rule an explicit `row` line already uses), `row_out_of_range` (a `row`
+past the grid, which would otherwise fold onto the last rule), and `text_below_region` (a flow
+line whose baseline falls below the region box). Treat any of these as "re-layout", not noise —
+an unattended write has no human to notice the pile-up.
+
 ## Use the placement the server already does for you
 
 - **Schedule by clock time, not coordinates.** Give each line a `time: "HH:MM"`; the server

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,33 @@ roadmap holds only planned feature development (bugs/polish live on the
 
 ---
 
+## Fix: sub-hour times interpolate, row pile-ups warn, tagged `art-header` + hour gutter — 2026-08-20
+
+[#32](https://github.com/bsitkoff/onion_planner_mcp/issues/32),
+[#30](https://github.com/bsitkoff/onion_planner_mcp/issues/30),
+[#31](https://github.com/bsitkoff/onion_planner_mcp/issues/31),
+[#45](https://github.com/bsitkoff/onion_planner_mcp/issues/45),
+[#44](https://github.com/bsitkoff/onion_planner_mcp/issues/44) (code half). A `13:30` event drew on
+the 2 PM rule (`rowForTime` rounded to a whole row — `.5` rounds up), 30 `row`s into a 15-row grid
+piled 16 strings onto the last rule with `warnings: []`, 40 flow lines ran 500px past the `ainotes`
+box silently, and the docs promised a "more lines than ruled rows" warning that never existed.
+
+- **`rowForTime` is fractional; `ruledY` interpolates** between rules for both plain `time` lines
+  and washi blocks (a 13:30–14:30 block starts halfway down the 1 PM interval). Whole hours are
+  bit-identical to before; the one-interval minimum block height still applies (`r2 − r1 < 1`).
+- **New warnings:** `row_out_of_range` (names the clamp instead of folding silently),
+  `row_collision` (two different `lines[]` entries on one baseline — wrapped continuations of one
+  entry never count, headings exempt; #31's distinction), `text_below_region` (a single-segment
+  baseline + descender below the box; wrapped blocks were already covered).
+- **Tagged art slot (onionskin#224):** `parseRegions` prefers a nested
+  `<rect data-region="art-*">` as `Region.artSlot` (+ new `artSlotName`), falling back to the
+  untagged dashed rect the live library's frozen pages still print. The region's own box is now
+  the first rect with *no* `data-region` — no longer "the first rect", which would have made the
+  300px art rect the header's box had it ever been listed first.
+- **`Region.gutterX`** (where the horizontal rules start: 34 on the cozy/colorful schedule +
+  agenda, which print an IBM Plex Mono hour gutter; 0 on minimal) — default text/block x is
+  `max(xPad, gutterX)` so nothing overdraws the printed hour numbers. Explicit `x` still wins.
+
 ## Fix: header images size/place against the illustration sub-box, not the full band — 2026-08-20
 
 [#45](https://github.com/bsitkoff/onion_planner_mcp/issues/45). A daily `header` group ships a

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,9 +146,12 @@ server.tool(
     "a weekday header, hour-line numbers), in document order, empty if the template prints " +
     "nothing here; check it before writing a line so you don't double-write content the " +
     "template already shows (e.g. the date under a template that already prints \"TODAY\"), " +
-    "`artSlot` — a printed dashed illustration drop-zone nested in the region (e.g. the " +
-    "header's right-side banner box), region-local {x,y,width,height} or null; when present, " +
-    "image placement (corner/fit) and sizing target it, not the full region box, " +
+    "`artSlot` — a printed illustration drop-zone nested in the region (the header's " +
+    "right-side banner box, tagged `art-header` on newer templates — `artSlotName` — or an " +
+    "untagged dashed rect on older pages), region-local {x,y,width,height} or null; when present, " +
+    "image placement (corner/fit) and sizing target it, not the full region box (address it " +
+    "through its parent region — it is not a region name), `gutterX` — where a ruled region's " +
+    "rules start (the printed hour-label gutter; default x never sits left of it), " +
     "`imageFloor` — the {width,height} a centered image below trips `image_small_for_region` " +
     "in this region (245×245 when `intent` marks it interactive, e.g. a habit tracker the " +
     "user pencil-checks; else 35% of the box, or of the `artSlot` when it has one), so you " +

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -679,15 +679,34 @@ function bannerLabelWidth(text: string, size: number): number {
 const BANNER_PAD_X = 12;
 
 /**
- * Map a clock time ("HH:MM", 24-hour) to a ruled-row index, given the hour at
- * row 0 and how many rows cover an hour. Rounds to the nearest row. Throws on a
- * malformed time string. The caller clamps/validates the resulting row range.
+ * Map a clock time ("HH:MM", 24-hour) to a **fractional** ruled-row index, given the
+ * hour at row 0 and how many rows cover an hour — `13:30` on a 1-row-per-hour grid
+ * starting at 7 is row 6.5, halfway between the 1 PM and 2 PM rules (#32; it used to
+ * round to the nearest whole row, which drew a 1:30 event on the 2:00 line). Throws
+ * on a malformed time string. The caller clamps/validates the resulting row range
+ * and resolves the fraction to a y via `ruledY`.
  */
 function rowForTime(time: string, startHour: number, rowsPerHour: number): number {
   const m = /^([01]?\d|2[0-3]):([0-5]\d)$/.exec(time.trim());
   if (!m) throw new Error(`time must be "HH:MM" (24-hour), got "${time}".`);
   const minutesFromStart = (Number(m[1]) * 60 + Number(m[2])) - startHour * 60;
-  return Math.round((minutesFromStart / 60) * rowsPerHour);
+  return (minutesFromStart / 60) * rowsPerHour;
+}
+
+/**
+ * Absolute y of a (possibly fractional) row index on a ruled region: the ruled line
+ * at `floor(row)` plus the fraction of the interval to the next line. Clamped to the
+ * grid, so callers warn about out-of-range rows themselves. A whole-number row is
+ * exactly its ruled line (bit-identical to the pre-#32 behaviour).
+ */
+function ruledY(region: Region, row: number): number {
+  const r = region.ruledLines;
+  const maxIdx = r.length - 1;
+  const c = Math.min(Math.max(0, row), maxIdx);
+  const i = Math.floor(c);
+  const frac = c - i;
+  if (frac === 0 || i >= maxIdx) return r[i];
+  return r[i] + frac * (r[i + 1] - r[i]);
 }
 
 /**
@@ -1589,12 +1608,15 @@ export function composeAiSvg(
       // above/between the ruled lines, leaving the lines free for the user's ink.
       // A line with an explicit `row` or `time` still snaps to the ruled grid.
       const flowBases = flowBaselines(region, lines, def, theme);
+      // baseline y -> the text of the `lines[]` entry that owns it (row_collision, #30).
+      const baselineOwners = new Map<number, string>();
       lines.forEach((line, i) => {
         const size = line.size ?? def.size;
         const font = line.font ?? themeFontFor(theme, region.name, !!line.heading) ?? def.font;
         const weight = line.weight ?? def.weight;
         const fill = line.fill !== undefined ? floorTextFill(line.fill) : baseFill;
-        let x = line.x ?? def.xPad ?? DEFAULT_X_PAD;
+        // Inset at least past the template's printed hour-label gutter (#44).
+        let x = line.x ?? Math.max(def.xPad ?? DEFAULT_X_PAD, region.gutterX ?? 0);
 
         // A washi-tape duration block: `time` + (`endTime`/`durationMin`) draws a
         // rounded, tinted rect spanning start->end rows instead of a single baseline —
@@ -1654,13 +1676,19 @@ export function composeAiSvg(
               region.name,
             );
           } else {
-            if (r2 <= r1) {
+            if (r2 - r1 < 1) {
               // Min block height is one schedule-line interval, read from the template's
               // ruled lines (2026-07-09 decisions; spec: design/UNDERLAY-VISUAL.md,
               // forthcoming) — a 20-min meeting on a 1-row-per-hour grid still draws a
               // visible tape, not a bare text line. Supersedes the old sub-hour
-              // plain-line fallback (#17).
+              // plain-line fallback (#17). Rows are fractional (#32), so "shorter than
+              // one interval" is `r2 - r1 < 1`, and a block that starts mid-interval
+              // near the grid's end shifts up rather than spilling past the last rule.
               r2 = r1 + 1;
+              if (r2 > maxIdx) {
+                r2 = maxIdx;
+                r1 = maxIdx - 1;
+              }
               warn(
                 "washi_block_min_height",
                 `region "${region.name}": block "${truncate(line.text)}" (${line.time}–${endTimeStr}) ` +
@@ -1669,9 +1697,10 @@ export function composeAiSvg(
                 region.name,
               );
             }
-            const y1 = Math.round(region.ruledLines[r1] - region.y);
-            const y2 = Math.round(region.ruledLines[r2] - region.y);
-            const bx = line.x ?? def.xPad ?? DEFAULT_X_PAD;
+            const y1 = Math.round(ruledY(region, r1) - region.y);
+            const y2 = Math.round(ruledY(region, r2) - region.y);
+            // Never start left of the template's printed hour-label gutter (#44).
+            const bx = line.x ?? Math.max(def.xPad ?? DEFAULT_X_PAD, region.gutterX ?? 0);
             // Right inset is the standard margin, not a second helping of the schedule's
             // wide LEFT gutter (reserved for the printed hour labels) — re-subtracting it
             // on the right left the tape ~half its column narrower than it needed to be.
@@ -1715,8 +1744,10 @@ export function composeAiSvg(
           );
         }
 
-        // Resolve a clock time to a ruled row (precedence: y > row > time).
+        // Resolve a clock time to a ruled row (precedence: y > row > time). The row is
+        // fractional for a sub-hour time (#32) — `ruledY` interpolates it below.
         let effLine = line;
+        let rowFromTime = false;
         if (line.time !== undefined && line.y === undefined && line.row === undefined) {
           if (region.ruledLines.length === 0) {
             warn(
@@ -1747,6 +1778,7 @@ export function composeAiSvg(
               );
             }
             effLine = { ...line, row: r };
+            rowFromTime = true;
           }
         }
 
@@ -1755,11 +1787,41 @@ export function composeAiSvg(
         if (effLine.y !== undefined) {
           y = effLine.y;
         } else if (effLine.row !== undefined && region.ruledLines.length > 0) {
-          const idx = Math.min(Math.max(0, Math.floor(effLine.row)), region.ruledLines.length - 1);
-          const localRuled = region.ruledLines[idx] - region.y;
+          const maxIdx = region.ruledLines.length - 1;
+          if (!rowFromTime && (effLine.row < 0 || effLine.row > maxIdx)) {
+            // Don't fold an out-of-range row onto the last rule silently — that's how
+            // 30 lines into a 15-row grid piled 16 strings onto one baseline (#30).
+            warn(
+              "row_out_of_range",
+              `region "${region.name}": line "${truncate(line.text)}" asks for row ` +
+                `${effLine.row} but the grid has rows 0–${maxIdx} — clamped to row ` +
+                `${Math.min(Math.max(0, effLine.row), maxIdx)}.`,
+              "warning",
+              region.name,
+            );
+          }
+          const localRuled = ruledY(region, effLine.row) - region.y;
           y = Math.round(localRuled + rowOffset(region));
         } else {
           y = Math.round(flowBases[i]);
+        }
+
+        // Two different `lines[]` entries on one baseline are a collision — unrelated
+        // strings stacked in the same visual slot (#30/#31). Wrapped continuations of a
+        // single entry are one item and never count; headings are labels and exempt.
+        if (!line.heading) {
+          const prior = baselineOwners.get(y);
+          if (prior !== undefined) {
+            warn(
+              "row_collision",
+              `region "${region.name}": line "${truncate(line.text)}" lands on the same ` +
+                `baseline (y=${y}) as "${truncate(prior)}" — two items in one slot.`,
+              "warning",
+              region.name,
+            );
+          } else {
+            baselineOwners.set(y, line.text);
+          }
         }
 
         // A section heading. `banner` themes draw a coloured pill + white label
@@ -1837,6 +1899,23 @@ export function composeAiSvg(
               `font-size="${size}" font-weight="${weight}" fill="${fill}">${escapeXml(seg)}</text>`,
           );
         });
+
+        // A single-segment line whose baseline (+ descender) sits below the region box
+        // is drawn into whatever lies underneath — 40 flow lines into a 422px box used to
+        // do this with `warnings: []` (#30). Wrapped blocks are covered below.
+        if (
+          segments.length === 1 &&
+          region.height !== null &&
+          y + Math.round(size * 0.3) > region.height
+        ) {
+          warn(
+            "text_below_region",
+            `region "${region.name}": line "${truncate(line.text)}" (baseline y=${y}) ` +
+              `falls below the ${region.height}px region box.`,
+            "warning",
+            region.name,
+          );
+        }
 
         if (region.width !== null) {
           if (!effWrap) {

--- a/src/template.ts
+++ b/src/template.ts
@@ -70,6 +70,20 @@ export interface Region {
    */
   artSlot: { x: number; y: number; width: number; height: number } | null;
   /**
+   * The `data-region` name the template gives its art slot (e.g. `"art-header"`, app
+   * catalogue ≥ `14-art-header-region`), or null when the slot was detected from an
+   * untagged dashed rect (pages created from the older catalogue) or there is none.
+   * The slot is addressed through its parent region either way — it is not a region.
+   */
+  artSlotName: string | null;
+  /**
+   * Region-local x where the horizontal ruled lines start — the printed hour-label
+   * gutter on the cozy/colorful schedule + agenda templates (34), 0 on the minimal
+   * ones. Blocks and text inset to at least this x so they never overdraw the printed
+   * hour numbers (#44). null when the region has no horizontal rules.
+   */
+  gutterX: number | null;
+  /**
    * Text the template itself already prints inside this region's `<g>` (a section
    * label like "Schedule", chrome like "TODAY"/"DATE", a weekday header, hour-line
    * numbers) — in document order. Empty when the template prints nothing here. Lets
@@ -346,47 +360,50 @@ export function parseRegions(templateSvg: string, templateName?: string): Region
     const name: string = g["@_data-region"] ?? id.replace(/^region-/, "");
 
     // A region's <g> may nest one or more other <rect>s (a decorative border, a dot
-    // pattern) plus a dashed <rect data-region="label-<name>"> sub-region (the printed
-    // label slot) alongside its own box rect. Disambiguate the label rect by its
-    // "label-" prefix rather than assuming it's absent/last — order isn't guaranteed
-    // across templates, and the box rect is whichever non-label rect comes first.
+    // pattern) plus tagged sub-boxes: a dashed <rect data-region="label-<name>"> (the
+    // printed section-label slot) and, on the daily headers, <rect data-region=
+    // "art-header"> (the banner-art drop-zone; app catalogue ≥ 14-art-header-region).
+    // The region's own box is the first rect carrying NO data-region — never infer it
+    // from document order, which isn't guaranteed across templates.
     const rects: any[] = Array.isArray(g.rect) ? g.rect : g.rect ? [g.rect] : [];
-    const labelRect = rects.find(
-      (r) => typeof r["@_data-region"] === "string" && r["@_data-region"].startsWith("label-"),
-    );
-    const rect = rects.find((r) => r !== labelRect) ?? null;
+    const tagOf = (r: any): string | null =>
+      typeof r["@_data-region"] === "string" ? r["@_data-region"] : null;
+    const labelRect = rects.find((r) => tagOf(r)?.startsWith("label-"));
+    const rect =
+      rects.find((r) => tagOf(r) === null) ??
+      rects.find((r) => r !== labelRect && !tagOf(r)?.startsWith("art-")) ??
+      null;
     const width = rect ? num(rect["@_width"]) : null;
     const height = rect ? num(rect["@_height"]) : null;
-    const labelSlot = labelRect
-      ? {
-          x: num(labelRect["@_x"]) ?? 0,
-          y: num(labelRect["@_y"]) ?? 0,
-          width: num(labelRect["@_width"]) ?? 0,
-          height: num(labelRect["@_height"]) ?? 0,
-        }
-      : null;
-    // A dashed rect with no `data-region` (distinct from the box and any label slot) is
-    // the region's illustration placeholder — the AI banner-art drop-zone (#45).
-    // Detected by its `stroke-dasharray` so it's never confused with the region's box.
-    const artRect = rects.find(
-      (r) =>
-        r !== labelRect &&
-        r !== rect &&
-        typeof r["@_stroke-dasharray"] === "string" &&
-        r["@_stroke-dasharray"].trim() !== "",
-    );
-    const artSlot = artRect
-      ? {
-          x: num(artRect["@_x"]) ?? 0,
-          y: num(artRect["@_y"]) ?? 0,
-          width: num(artRect["@_width"]) ?? 0,
-          height: num(artRect["@_height"]) ?? 0,
-        }
-      : null;
+    const box = (r: any) => ({
+      x: num(r["@_x"]) ?? 0,
+      y: num(r["@_y"]) ?? 0,
+      width: num(r["@_width"]) ?? 0,
+      height: num(r["@_height"]) ?? 0,
+    });
+    const labelSlot = labelRect ? box(labelRect) : null;
+    // The illustration placeholder — the AI banner-art drop-zone (#45). Preferred: the
+    // app-tagged `data-region="art-*"` rect (onionskin#224). Fallback for pages whose
+    // frozen template.svg predates the tag (the live library — the app never migrates a
+    // page that already carries an underlay): an untagged dashed rect that is neither the
+    // box nor the label slot, detected by its `stroke-dasharray`.
+    const artRect =
+      rects.find((r) => tagOf(r)?.startsWith("art-")) ??
+      rects.find(
+        (r) =>
+          r !== labelRect &&
+          r !== rect &&
+          tagOf(r) === null &&
+          typeof r["@_stroke-dasharray"] === "string" &&
+          r["@_stroke-dasharray"].trim() !== "",
+      );
+    const artSlot = artRect ? box(artRect) : null;
+    const artSlotName = artRect ? tagOf(artRect) : null;
 
     const lines: any[] = Array.isArray(g.line) ? g.line : g.line ? [g.line] : [];
     const ruledLines: number[] = [];
     const colLines: number[] = [];
+    let gutterX: number | null = null;
     for (const ln of lines) {
       const x1 = num(ln["@_x1"]);
       const y1 = num(ln["@_y1"]);
@@ -394,6 +411,8 @@ export function parseRegions(templateSvg: string, templateName?: string): Region
       const y2 = num(ln["@_y2"]);
       if (y1 !== null && y2 !== null && Math.abs(y1 - y2) < 0.5) {
         ruledLines.push(y + y1); // horizontal rule -> absolute y
+        const start = Math.min(x1 ?? 0, x2 ?? x1 ?? 0);
+        gutterX = gutterX === null ? start : Math.min(gutterX, start);
       } else if (x1 !== null && x2 !== null && Math.abs(x1 - x2) < 0.5) {
         colLines.push(x + x1); // vertical rule -> absolute x
       }
@@ -433,6 +452,8 @@ export function parseRegions(templateSvg: string, templateName?: string): Region
       colLines,
       labelSlot,
       artSlot,
+      artSlotName,
+      gutterX,
       printedText,
     });
   }

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -177,9 +177,25 @@ async function main() {
     !!schedule?.labelSlot && schedule.width !== schedule.labelSlot.width && schedule.height !== schedule.labelSlot.height,
     JSON.stringify({ box: [schedule?.width, schedule?.height], slot: schedule?.labelSlot }),
   );
-  // header's dashed art-banner rect has no data-region, so it's NOT a label slot.
+  // header's dashed art-banner rect is tagged data-region="art-header" (catalogue ≥ 14,
+  // onionskin#224) — an art slot, NOT a label slot, and never a region of its own.
   const header = read.regions.find((r) => r.name === "header");
-  check("header's decorative dashed rect (no data-region) is not read as a label slot", header?.labelSlot === null, JSON.stringify(header?.labelSlot));
+  check("header's tagged art-header rect is not read as a label slot", header?.labelSlot === null, JSON.stringify(header?.labelSlot));
+  check("the tagged art rect is surfaced by name (artSlotName = art-header)", header?.artSlotName === "art-header", String(header?.artSlotName));
+  check("art-header is addressed through header, not listed as a region", !read.regions.some((r) => r.name === "art-header"), JSON.stringify(read.regions.map((r) => r.name)));
+  check("header's box is the untagged 912-wide rect, not the 300px art rect", header?.width === 912 && header?.height === 116, JSON.stringify([header?.width, header?.height]));
+  // The live library's pages froze the PRE-#224 template (an untagged dashed rect), and
+  // the app never migrates a page that already carries an underlay — so both shapes
+  // must resolve to the same slot, regardless of rect order inside the <g>.
+  const legacyHeader = (order: "box-first" | "art-first") => {
+    const boxR = '<rect x="0" y="0" width="912" height="116" fill="none"/>';
+    const artR = '<rect x="612" y="6" width="300" height="104" rx="12" fill="none" stroke="#D9CFE3" stroke-dasharray="3 5"/>';
+    return parseRegions(`<svg viewBox="0 0 1024 1366" xmlns="http://www.w3.org/2000/svg"><g id="region-header" data-region="header" data-fill="ai" transform="translate(56,84)">${order === "box-first" ? boxR + artR : artR + boxR}</g></svg>`).find((r) => r.name === "header");
+  };
+  const legacy = legacyHeader("box-first");
+  check("an untagged dashed rect (live pages) still resolves as artSlot, artSlotName null", legacy?.artSlot?.width === 300 && legacy?.artSlotName === null && legacy?.width === 912, JSON.stringify(legacy));
+  const taggedFirst = parseRegions('<svg viewBox="0 0 1024 1366" xmlns="http://www.w3.org/2000/svg"><g id="region-header" data-region="header" transform="translate(56,84)"><rect x="612" y="6" width="300" height="104" stroke-dasharray="3 5" data-region="art-header" data-fill="ai"/><rect x="0" y="0" width="912" height="116" fill="none"/></g></svg>').find((r) => r.name === "header");
+  check("a tagged art rect listed BEFORE the box rect is still the slot, not the box", taggedFirst?.width === 912 && taggedFirst?.artSlot?.x === 612 && taggedFirst?.artSlotName === "art-header", JSON.stringify(taggedFirst));
   // #45: the dashed illustration rect IS surfaced as `artSlot` — the intended image
   // drop-zone — so image sizing/floors target it, not the full header band.
   check("header exposes its dashed illustration rect as artSlot", !!header?.artSlot && header.artSlot.width === 300 && header.artSlot.height === 104, JSON.stringify(header?.artSlot));
@@ -381,6 +397,75 @@ async function main() {
     await writeUnderlay(root, daily, { status: "ready", dryRun: true, regions: [{ region: "schedule", startHour: 8, lines: [{ text: "x", time: "9am" }] }] });
   } catch { badTime = true; }
   check("rejects malformed time string", badTime);
+
+  console.log("\n#32 sub-hour times interpolate between rules; #30/#31 row discipline; #44 gutter");
+  const pitch = rl[1] - rl[0];
+  const off = Math.round(pitch * 0.4);
+  // 13:30 on the schedule's own grid (startHour 7, 1 row/hour) is row 6.5 — the baseline
+  // must sit halfway between the 1 PM and 2 PM rules, not on the 2 PM rule (it used to).
+  const halfHour = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "schedule", lines: [{ text: "onethirty", time: "13:30" }, { text: "twopm", time: "14:00" }] }],
+  });
+  const y130 = yOf(halfHour.aiSvg, ">onethirty</text>");
+  const y200 = yOf(halfHour.aiSvg, ">twopm</text>");
+  check("13:30 line sits halfway between the 13:00 and 14:00 rules", y130 === Math.round(rl[6] + pitch / 2 + off), `y=${y130} expected=${Math.round(rl[6] + pitch / 2 + off)} (rules ${rl[6]}..${rl[7]})`);
+  check("13:30 line is above the 14:00 line (no longer snapped onto it)", y130 < y200 && y200 === Math.round(rl[7] + off), `${y130} vs ${y200}`);
+  check("a sub-hour time does not collide-warn against the next hour", !halfHour.warningDetails.some((w) => w.code === "row_collision"), JSON.stringify(halfHour.warnings));
+  // A washi block 13:30–14:30 starts mid-interval and spans one full interval.
+  const halfBlock = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "schedule", lines: [{ text: "Dentist", time: "13:30", endTime: "14:30" }] }],
+  });
+  const halfRect = (regionGroup(halfBlock.aiSvg, "schedule") ?? "").match(/<rect[^>]*fill-opacity="[\d.]+"[^>]*\/>/);
+  const hbY = Number(halfRect?.[0].match(/ y="(-?\d+)"/)?.[1]);
+  const hbH = Number(halfRect?.[0].match(/height="(\d+)"/)?.[1]);
+  check("13:30–14:30 block starts halfway down the 13:00 interval", hbY === Math.round(rl[6] + pitch / 2), `y=${hbY} expected=${Math.round(rl[6] + pitch / 2)}`);
+  check("13:30–14:30 block spans one full interval", Math.abs(hbH - pitch) <= 1, `h=${hbH} pitch=${pitch}`);
+  check("a mid-interval one-hour block is NOT flagged below the minimum height", !halfBlock.warningDetails.some((w) => w.code === "washi_block_min_height"), JSON.stringify(halfBlock.warnings));
+  // #30 repro 2: 30 rows into a 15-row grid used to fold 16 strings onto the last rule
+  // with `warnings: []`. Now each out-of-range row warns, and the pile-up is a collision.
+  const tooManyRows = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "schedule", lines: Array.from({ length: rl.length + 3 }, (_, i) => ({ text: `item ${i}`, row: i })) }],
+  });
+  check("an out-of-range row warns row_out_of_range (naming the clamp)", tooManyRows.warningDetails.filter((w) => w.code === "row_out_of_range").length === 3, JSON.stringify(tooManyRows.warningDetails.map((w) => w.code)));
+  check("two entries folded onto one baseline warn row_collision", tooManyRows.warningDetails.some((w) => w.code === "row_collision" && w.message.includes(`item ${rl.length}`)), JSON.stringify(tooManyRows.warnings));
+  // A time-anchored line landing on an explicit-row line is the realistic collision.
+  const mixed = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "schedule", lines: [{ text: "by row", row: 2 }, { text: "by time", time: "09:00" }] }],
+  });
+  check("a time line on the same rule as a row line warns row_collision", mixed.warningDetails.some((w) => w.code === "row_collision"), JSON.stringify(mixed.warnings));
+  // #31: wrapped continuations of ONE entry are one item — never a collision.
+  const wrappedItems = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "ainotes", lines: [
+      { text: "Important", heading: true },
+      { text: "A long note that certainly wraps onto a second and probably a third line inside the ainotes box today." },
+      { text: "Second item" },
+    ] }],
+  });
+  check("a wrapped paragraph + following item produce no row_collision / text_below_region", !wrappedItems.warningDetails.some((w) => w.code === "row_collision" || w.code === "text_below_region"), JSON.stringify(wrappedItems.warnings));
+  // #30 repro 1: 40 flow lines into the ainotes box ran 500px past its floor, silently.
+  const overflowBox = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "ainotes", lines: Array.from({ length: 40 }, (_, i) => ({ text: `note ${i}`, wrap: false })) }],
+  });
+  check("flow text past the bottom of a box region warns text_below_region", overflowBox.warningDetails.some((w) => w.code === "text_below_region"), JSON.stringify(overflowBox.warnings.slice(0, 3)));
+  check("a short fitting list does not warn text_below_region", !wrappedItems.warningDetails.some((w) => w.code === "text_below_region"));
+  // #44: the cozy/colorful schedule + agenda print an IBM Plex Mono hour gutter; their
+  // rules start at x=34. The minimal moods print none (rules from x=0). Blocks and text
+  // never start left of the gutter.
+  check("daily-minimal schedule gutterX is 0 (no printed hour labels)", schedule?.gutterX === 0, String(schedule?.gutterX));
+  check("daily-cozy schedule gutterX is 34 (printed hour gutter)", cozyScheduleRegion?.gutterX === 34, String(cozyScheduleRegion?.gutterX));
+  const cozyRegions = parseRegions(cozyScheduleTemplateSvg, "daily-cozy");
+  const cozyBlock = composeAiSvg([1024, 1366], [{ region: "schedule", lines: [{ text: "Sync", time: "09:00", endTime: "10:00", x: 10 }] }], cozyRegions);
+  const cozyTape = (regionGroup(cozyBlock.svg, "schedule") ?? "").match(/<rect[^>]*fill-opacity="[\d.]+"[^>]*\/>/);
+  check("an explicit x still wins (caller's call)", Number(cozyTape?.[0].match(/ x="(-?[\d.]+)"/)?.[1]) === 10, cozyTape?.[0]);
+  const cozyDefault = composeAiSvg([1024, 1366], [{ region: "schedule", lines: [{ text: "Sync", time: "09:00", endTime: "10:00" }] }], cozyRegions);
+  const cozyTapeDefault = (regionGroup(cozyDefault.svg, "schedule") ?? "").match(/<rect[^>]*fill-opacity="[\d.]+"[^>]*\/>/);
+  check("a default-placed cozy block starts at or right of the 34px hour gutter", Number(cozyTapeDefault?.[0].match(/ x="(-?[\d.]+)"/)?.[1]) >= 34, cozyTapeDefault?.[0]);
 
   console.log("\nwashi-tape duration blocks (time + endTime/durationMin; dry-run)");
   const washi = await writeUnderlay(root, daily, {


### PR DESCRIPTION
## Summary
- **#32** `rowForTime` is fractional and `ruledY` interpolates between ruled lines — a 13:30 event starts halfway down the 1 PM interval (plain lines and washi blocks); whole hours unchanged.
- **#30/#31** new warnings `row_out_of_range`, `row_collision` (two different `lines[]` entries on one baseline; wrapped continuations of one entry never count), `text_below_region`. CLAUDE.md no longer promises a warning that didn't exist.
- **#45** `parseRegions` prefers the app-tagged `<rect data-region="art-header">` (onionskin#224, catalogue 14) and falls back to the untagged dashed rect that live pages still print; the region box is the first rect with *no* `data-region`. New `artSlotName`.
- **#44 (code half)** `Region.gutterX` + default x = `max(xPad, gutterX)` so blocks never overdraw the cozy/colorful hour gutter. Spec truth-up follows in the next PR.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run smoke` — 378 passed, 0 failed (21 new checks)
- [x] live `read_page Shared/2026-08/2026-08-21`: untagged rect → `artSlot {612,6,300,104}`, `artSlotName null`
- [x] live dry-run: 13:30–14:30 block y=391 (mid-interval), `row_collision` fires for a row line under a time line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEFvwptDc4jKCm5UXRK43k