### PR TITLE
fix: month-chapter year/month stamp + chronological order (#43); spec re-verification (#44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,9 +240,13 @@ pages, so catalogue instantiation is how the first page in a chapter gets made.
 - **The app renderer is a custom SVG subset** (SwiftUI `Canvas` + `XMLParser`, no WebKit):
   it handles `svg, g, rect, line, path, text, image, circle, ellipse, polyline, polygon`
   (`RAW_SVG_ALLOWED_ELEMENTS` in `src/svg.ts` is the source of truth) and silently drops
-  anything else — notably `<tspan>`, which is why multi-line text is stacked `<text>`.
-  `text-anchor`/`font-weight` do **not** inherit from a wrapping `<g>` (app
-  [#211](https://github.com/bsitkoff/onionskin/issues/211)) — set them per `<text>`.
+  anything else. Since app build 121 (onionskin#212) a `<tspan>` carrying `x`/`y`/`dy` starts a
+  new line inside one `<text>` (no per-run font/fill — a bare tspan still flattens into the
+  parent run with a space); this server's structured output keeps emitting stacked `<text>`
+  per line, and its raw-svg validator's tspan acceptance is tracked in #42. `font-family`,
+  `font-size`, `font-weight`, `text-anchor` and `fill` now **inherit from a wrapping `<g>`**
+  (onionskin#211 fixed; a value on the `<text>` wins) — older builds dropped the anchor/weight,
+  so per-`<text>` attributes remain the safest form.
   `<image href>` resolves **only as a page-relative file path** (no data-URIs) and the
   **AI layer needs a non-nil `imageProvider`** (an app change) for images to appear at all.
   When emitting raw `svg`, stay within that element set.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,29 @@ roadmap holds only planned feature development (bugs/polish live on the
 
 ---
 
+## Fix: minted month chapters carry `year`/`month`; spec re-verified (hour gutter, no printed checkboxes) — 2026-08-20
+
+[#43](https://github.com/bsitkoff/onion_planner_mcp/issues/43),
+[#44](https://github.com/bsitkoff/onion_planner_mcp/issues/44). On Aug 1 create-on-write reached
+`Shared/2026-08` before the app had, leaving a `.folder.json` with no `year`/`month` — month-ness
+is metadata, never the folder name, so the app saw a plain chapter (no overview, no day
+materialization). And `SHARED-VISUAL-SPEC.md` §1/§2 still carried 2026-06 "Verified" claims that
+the catalogue had since inverted.
+
+- **`createPage` stamps `year` + `month`** when it mints a `YYYY-MM` chapter, merging into any
+  existing config (other keys preserved) and writing **no placeholder `title`** — a non-empty
+  title blocks the app from filling "September 2026". Non-month chapters are unchanged.
+- **`order` is inserted chronologically** among `YYYY-MM-DD` siblings (a back-filled earlier day
+  no longer lands after later ones); non-date names keep their positions.
+- **Spec re-verified 2026-08-20 against catalogue 14:** hour labels are per style (cozy/colorful
+  schedule + agenda print a 34px IBM Plex Mono gutter; minimal none) and **no shipped template
+  prints checkbox squares** — so the template-id-keyed `printed_checkboxes` warning
+  (`PRINTS_OWN_CHECKBOXES_RE`) is retired: authors always draw `marker: "checkbox"`. A smoke
+  check now audits the catalogue for printed boxes instead of trusting a list. The same facts are
+  corrected in `ON-DEVICE-UNDERLAY.md` and `MCP-INTEGRATION.md`; CLAUDE.md's renderer gotcha is
+  trued up to the app's shipped `<tspan x/y/dy>` support and `<g>`-inherited
+  `text-anchor`/`font-weight` (onionskin#211/#212).
+
 ## Fix: sub-hour times interpolate, row pile-ups warn, tagged `art-header` + hour gutter — 2026-08-20
 
 [#32](https://github.com/bsitkoff/onion_planner_mcp/issues/32),

--- a/docs/MCP-INTEGRATION.md
+++ b/docs/MCP-INTEGRATION.md
@@ -109,7 +109,7 @@ portrait points). All your geometry is in this space.
 <svg viewBox="0 0 1024 1366" xmlns="http://www.w3.org/2000/svg">
   <g id="region-schedule" data-region="schedule" transform="translate(56,250)">
     <rect x="0" y="0" width="540" height="870" fill="none"/>
-    <!-- ruled hour lines + labels … -->
+    <!-- ruled hour lines (+ a printed hour gutter on the cozy/colorful styles) … -->
   </g>
   <g id="region-ainotes" data-region="ainotes" data-fill="ai" transform="translate(678,734)">…</g>
   <g id="region-todo"        data-region="todo"        transform="translate(636,520)">…</g>

--- a/docs/ON-DEVICE-UNDERLAY.md
+++ b/docs/ON-DEVICE-UNDERLAY.md
@@ -61,6 +61,7 @@ layout. That visual spec, not a shared codebase, is the contract between the two
 resolved 2026-06) and its agreed parts (§0–4 + markers) are mirrored into
 `../onionskin/design/FORMAT.md`. The on-device composer matches it on its subset (schedule
 agenda, to-do text, note band, monthly markers) and draws **no banners** (§5 is MCP-only). Key
-resolved points for this author: the chapter's own ink palette, lifted for the underlay (gold is retired); schedule is agenda-style (no
-printed hour labels); write to-do **text only** where the template prints its own checkboxes;
-render **one quiet default style**, not a per-day theme.
+resolved points for this author: the chapter's own ink palette, lifted for the underlay (gold is retired); schedule is agenda-style
+(the cozy/colorful templates print an hour gutter — inset past `gutterX`; minimal prints none);
+no shipped template prints checkboxes, so to-do lines always draw their own marker (both claims
+re-verified 2026-08-20, issue #44); render **one quiet default style**, not a per-day theme.

--- a/docs/SHARED-VISUAL-SPEC.md
+++ b/docs/SHARED-VISUAL-SPEC.md
@@ -46,23 +46,31 @@
 ## 1. Schedule (agenda)
 
 - Text: **Mulish 15 / weight 600 / the resolved theme colour** (default: the chapter's own ink palette, lifted — gold retired).
-- **Resolved — no template prints hour labels.** Verified across the catalogue (e.g.
-  `daily-minimal` exposes `region-schedule` as ruled rows only, no `HH:00` gutter). So the
-  schedule reads as a **sequential agenda**: place items by `row` (snap to a ruled line), or by
-  clock `time` anchored via the region's `startHour` + `rowsPerHour` when the caller wants clock
-  alignment. There is no printed hour gutter to clear, so the `52px` schedule inset now acts as a
-  plain left margin (kept for breathing room; reduce to the `24px` default if a flush look is
-  wanted — cosmetic, safe either way).
+- **Re-verified 2026-08-20 against catalogue `14-art-header-region` (supersedes the 2026-06
+  "no template prints hour labels" claim — issue #44): hour labels are per *style*.** The
+  `*-minimal` schedule/agenda print ruled rows only (rules from region-local x=0, no gutter).
+  `daily-cozy`, `daily-colorful`, `agenda-cozy`, `agenda-colorful` print an **IBM Plex Mono 14 /
+  500 hour gutter** at region-local x<34; their rules start at x=34. The region reports where
+  its rules start as `gutterX` (`read_page`), and every default-placed line or block insets to
+  `max(xPad, gutterX)` — the `52px` schedule `xPad` already clears the 34px gutter, so on all
+  shipped templates the inset is effectively a margin; an explicit `x` is the caller's call.
+  Placement is agenda-style either way: by `row` (snap to a ruled line) or by clock `time`
+  anchored via the region's `startHour` + `rowsPerHour` (a sub-hour time interpolates between
+  rules — `13:30` is row 6.5).
 - Baseline: drop to `ruledLine + 0.40 × row-pitch` below the ruled line it lands on.
 
 ## 2. To-do list
 
 - Text: **Mulish 15 / 600 / the resolved theme colour**.
-- **Resolved — most templates print their own checkbox squares.** Verified: `todo-*` print a
-  full column of `26×26` boxes; `daily-cozy` / `daily-colorful` print ~7 in their to-do region;
-  `daily-minimal` prints none (ruled rows only). **Rule: inspect the template.** If it prints
-  boxes, the author writes **text only**, aligned to the ruled rows — do *not* also draw a marker
-  (that yields double boxes). If it prints none, the author may draw `marker: "checkbox"`.
+- **Re-verified 2026-08-20 against catalogue `14-art-header-region` (supersedes the 2026-06
+  "most templates print their own checkbox squares" claim — issue #44): no shipped template
+  prints checkbox squares.** Every to-do/list region (`todo`, `list-1/2/3`, on `todo-*` and the
+  dailies alike) is a bounding rect plus, on cozy/colorful, a panel/label-chip decoration; their
+  `data-intent` delegates box-drawing to the author. **Rule: the author draws
+  `marker: "checkbox"` on every to-do line** (the pre-#44 `printed_checkboxes` warning, which
+  told authors to write text-only on `todo-*`/cozy/colorful, is retired). A BYO template that
+  *does* print boxes should say so in its `data-intent`; inspect `printedText`/the template
+  before writing into one.
 - Checkbox marker (when author-drawn): square, side `round(0.85 × size)`, stroke
   `max(1, round(size/12))`, corner `rx 2`, `fill none`, themed stroke; box top = `baseline −
   side`; text starts at `box + round(0.4 × size)` past the left inset.
@@ -160,10 +168,12 @@ tint) instead of a solid fill — the only element in this file to use `fill-opa
 **`chromeAccent`** (the chapter's accent colour — a no-text fill, so it rides through raw),
 falling back to `theme.accent`, overridable per-block via `blockFill`. The label text sits
 vertically centred inside the block at `y1 + height − round(height × 0.28)` — the same centring
-ratio as §5's label-slot text. Left inset = the region's `xPad` (the schedule's gutter for its
-printed hour labels); right edge = `region.width − DEFAULT_X_PAD`, the *standard* margin — not
-the region's (often wider) `xPad` again, which would double-charge the left gutter on a side
-that has no hour labels to clear. A label too long to fit the block's width on one line wraps
+ratio as §5's label-slot text. Left inset = `max(xPad, gutterX)` — the region's `xPad`, never
+left of where its rules start (the printed hour gutter on cozy/colorful, §1); right edge =
+`region.width − DEFAULT_X_PAD`, the *standard* margin — not the region's (often wider) `xPad`
+again, which would double-charge the left gutter on a side that has no hour labels to clear.
+A block's start/end rows are **fractional** (`13:30–14:30` starts halfway down the 1 PM
+interval) — #32. A label too long to fit the block's width on one line wraps
 (reusing the same wrap heuristic as `ainotes`/`todo`), stacking centred within the block's
 height; if the wrapped lines still don't fit the block's height it warns
 `washi_block_label_overflow` rather than silently overrunning. A span partly outside the
@@ -180,10 +190,11 @@ where no block can fit, falls back to a plain time line (info `washi_block_zero_
    (≥4.5:1 on paper), pre-lightened underlay (lifted from the chapter's own ink palette, clamped
    at the floor), no reserved colours. Default palette source is the chapter's `paletteCharacter`.
    (§0)
-2. **Schedule:** no template prints hour labels → agenda placement (`row`, or `time` via
-   `startHour`/`rowsPerHour`); the 52px inset is now just a margin. (§1)
-3. **To-do:** most templates print their own checkboxes → author writes **text only** there;
-   draw a marker only when the template prints none. (§2)
+2. **Schedule:** hour labels are per style — minimal prints none, cozy/colorful print a 34px
+   gutter (`gutterX`); default inset is `max(xPad, gutterX)`. Agenda placement (`row`, or `time`
+   via `startHour`/`rowsPerHour`, sub-hour times interpolated). Re-verified 2026-08-20. (§1)
+3. **To-do:** no shipped template prints checkboxes → the author always draws
+   `marker: "checkbox"`. Re-verified 2026-08-20. (§2)
 4. **Note band:** wrap **on** for `ainotes` (free-text AI box); geometry from the region rect. (§3)
 5. **Monthly:** templates print no day numbers → author draws numbers + `data-date` rects;
    marker = a themed dot (+ optional label). (§4)

--- a/src/page.ts
+++ b/src/page.ts
@@ -1474,15 +1474,44 @@ export async function createPage(
     throw e;
   }
 
-  // Append to the chapter's page order. The page already exists at this point, so a
-  // corrupt .folder.json downgrades to a warning — not an error for a created page.
+  // Register the page in the chapter's `.folder.json`. The page already exists at this
+  // point, so a corrupt .folder.json downgrades to a warning — not an error for a created
+  // page. Merge into an existing config; never clobber keys we don't own.
   const warnings: string[] = [];
   try {
     const folderFile = path.join(chapterAbs, ".folder.json");
     const existing = await readIfExists(folderFile);
-    const folder = existing ? (JSON.parse(existing) as any) : { title: chapterName };
+    const folder = existing ? (JSON.parse(existing) as any) : {};
+    // A chapter named like a calendar month (`YYYY-MM`) IS a month chapter only if its
+    // config carries `year` + `month` — month-ness is metadata, never the folder name
+    // (app FORMAT.md §4, onionskin#215 / #43). When this server mints such a chapter
+    // (create-on-write reaching next month before the app has), stamp the pair. Leave
+    // `title` alone: a non-empty title blocks the app from filling "August 2026".
+    const monthMatch = /^(\d{4})-(0[1-9]|1[0-2])$/.exec(chapterName);
+    if (monthMatch) {
+      if (typeof folder.year !== "number") folder.year = Number(monthMatch[1]);
+      if (typeof folder.month !== "number") folder.month = Number(monthMatch[2]);
+    } else if (!existing) {
+      folder.title = chapterName;
+    }
     folder.order = Array.isArray(folder.order) ? folder.order : [];
-    if (!folder.order.includes(opts.name)) folder.order.push(opts.name);
+    if (!folder.order.includes(opts.name)) {
+      // Insert chronologically among dated siblings rather than appending: a calendar
+      // chapter reads oldest-first, and a back-filled earlier day must not land after
+      // later ones. Non-date names keep their positions; a page with no date, or a
+      // chapter with no dated sibling yet, appends.
+      const dateOf = (n: string) => (/^\d{4}-\d{2}-\d{2}$/.test(n) ? n : null);
+      const mine = dateOf(opts.name);
+      let at = folder.order.length;
+      if (mine !== null) {
+        const firstLater = folder.order.findIndex((n: string) => {
+          const d = dateOf(n);
+          return d !== null && d > mine;
+        });
+        if (firstLater !== -1) at = firstLater;
+      }
+      folder.order.splice(at, 0, opts.name);
+    }
     await atomicWrite(folderFile, JSON.stringify(folder, null, 2) + "\n");
   } catch (e: any) {
     warnings.push(

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -1263,14 +1263,6 @@ export interface ComposeResult {
 }
 
 /**
- * Templates that print their own to-do checkboxes (the locked visual rule in
- * `docs/SHARED-VISUAL-SPEC.md` §2): on these, an authored `marker: "checkbox"`
- * draws a second box beside the printed one. Matched on the template id — a
- * heuristic until printed-box detection reads the geometry itself.
- */
-const PRINTS_OWN_CHECKBOXES_RE = /^todo-|^daily(-weekend)?-(cozy|colorful)$/;
-
-/**
  * Compose a complete ai.svg document from structured region input, positioning
  * each line using the parsed region geometry. Throws if a region name is unknown.
  * Returns the SVG plus non-fatal `warnings` (estimated overflow, more lines than
@@ -1539,23 +1531,9 @@ export function composeAiSvg(
           );
         }
       }
-      // The locked visual rule: where the template prints its own checkboxes, the
-      // author writes text only — a `marker: "checkbox"` would draw a second box.
-      if (
-        templateName &&
-        PRINTS_OWN_CHECKBOXES_RE.test(templateName) &&
-        (region.name === "todo" || region.name.startsWith("list")) &&
-        lines.some((l) => l.marker === "checkbox")
-      ) {
-        warn(
-          "printed_checkboxes",
-          `region "${region.name}": template "${templateName}" prints its own ` +
-            `checkboxes — write text only (drop \`marker: "checkbox"\`) to avoid ` +
-            `double boxes.`,
-          "warning",
-          region.name,
-        );
-      }
+      // (No shipped template prints its own checkboxes — re-verified 2026-08-20 against
+      // catalogue 14, #44 — so the old `printed_checkboxes` warning, keyed on template id,
+      // is retired: authors always draw `marker: "checkbox"` on to-do lines.)
       // Body text uses the theme's ink; the ainotes box uses its serif colour
       // (quote/affirmation are legacy aliases for it).
       const baseFill =

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -1389,22 +1389,54 @@ async function main() {
     JSON.stringify(scheduleAfterLabel?.labelFilled),
   );
 
-  console.log("\nprinted-checkbox templates warn on a redundant checkbox marker");
+  console.log("\n#44: no shipped template prints checkboxes — a marker never warns printed_checkboxes");
   const todoPage = "Shared/Daily/todo-day";
   await createPage(root, { chapter: "Daily", name: "todo-day", title: "Lists", template: "todo-minimal" });
   const todoRead = await readPage(root, todoPage);
   const listRegion = todoRead.regions.find((r) => r.name.startsWith("list")) ?? todoRead.regions.find((r) => r.name === "todo");
   check("todo template exposes a list region", !!listRegion, JSON.stringify(todoRead.regions.map((r) => r.name)));
-  const doubleBox = await writeUnderlay(root, todoPage, {
+  // Verified against the catalogue itself, not a template-id list: no to-do/list region of
+  // any shipped template draws a checkbox square (a small <rect> beside its rules).
+  const catalogue = (await fs.readdir(path.join(root, "Templates"), { withFileTypes: true })).filter((d) => d.isDirectory()).map((d) => d.name);
+  let printedBoxTemplates: string[] = [];
+  for (const id of catalogue) {
+    const svgText = await fs.readFile(path.join(root, "Templates", id, "template.svg"), "utf8");
+    for (const r of parseRegions(svgText, id)) {
+      if (r.name !== "todo" && !r.name.startsWith("list")) continue;
+      const grp = svgText.match(new RegExp(`<g\\b[^>]*id="${r.id}"[\\s\\S]*?</g>`))?.[0] ?? "";
+      const smallRects = [...grp.matchAll(/<rect\b[^>]*width="(\d+(?:\.\d+)?)"[^>]*height="(\d+(?:\.\d+)?)"/g)].filter((m) => Number(m[1]) <= 30 && Number(m[2]) <= 30);
+      if (smallRects.length > 0) printedBoxTemplates.push(`${id}/${r.name}`);
+    }
+  }
+  check("catalogue audit: no shipped to-do/list region prints checkbox squares", printedBoxTemplates.length === 0, JSON.stringify(printedBoxTemplates));
+  const markerOnTodo = await writeUnderlay(root, todoPage, {
     status: "ready", dryRun: true,
     regions: [{ region: listRegion!.name, lines: [{ text: "Buy stamps", marker: "checkbox" }] }],
   });
-  check("checkbox marker on a printed-box template warns printed_checkboxes", doubleBox.warningDetails.some((w) => w.code === "printed_checkboxes"), JSON.stringify(doubleBox.warningDetails));
-  const textOnly = await writeUnderlay(root, todoPage, {
-    status: "ready", dryRun: true,
-    regions: [{ region: listRegion!.name, lines: [{ text: "Buy stamps" }] }],
-  });
-  check("text-only lines on the same template do not warn", !textOnly.warningDetails.some((w) => w.code === "printed_checkboxes"), JSON.stringify(textOnly.warningDetails));
+  check("a checkbox marker on todo-minimal draws a box and does not warn", !markerOnTodo.warningDetails.some((w) => w.code === "printed_checkboxes") && /<rect\b[^>]*rx="2"/.test(regionGroup(markerOnTodo.aiSvg, listRegion!.name) ?? ""), JSON.stringify(markerOnTodo.warningDetails));
+  const cozyTodo = parseRegions(cozyScheduleTemplateSvg, "daily-cozy");
+  const cozyMarker = composeAiSvg([1024, 1366], [{ region: "todo", lines: [{ text: "Buy stamps", marker: "checkbox" }] }], cozyTodo, undefined, "daily-cozy");
+  check("a checkbox marker on daily-cozy (formerly flagged) no longer warns", !cozyMarker.warningDetails.some((w) => w.code === "printed_checkboxes"), JSON.stringify(cozyMarker.warnings));
+
+  console.log("\n#43: minting a YYYY-MM chapter stamps year/month (no title); order is chronological");
+  await createPage(root, { chapter: "2026-09", name: "2026-09-15", template: "daily-minimal" });
+  const m43FolderFile = path.join(root, "Shared", "2026-09", ".folder.json");
+  let m43Folder = JSON.parse(await fs.readFile(m43FolderFile, "utf8"));
+  check("a freshly minted month chapter carries year + month", m43Folder.year === 2026 && m43Folder.month === 9, JSON.stringify(m43Folder));
+  check("no placeholder title is written (the app fills \"September 2026\")", !("title" in m43Folder), JSON.stringify(m43Folder));
+  await createPage(root, { chapter: "2026-09", name: "2026-09-03", template: "daily-minimal" });
+  await createPage(root, { chapter: "2026-09", name: "sketch-sept", template: "blank-minimal" });
+  await createPage(root, { chapter: "2026-09", name: "2026-09-08", template: "daily-minimal" });
+  m43Folder = JSON.parse(await fs.readFile(m43FolderFile, "utf8"));
+  check("a back-filled earlier day is inserted before later days, not appended", JSON.stringify(m43Folder.order) === JSON.stringify(["2026-09-03", "2026-09-08", "2026-09-15", "sketch-sept"]), JSON.stringify(m43Folder.order));
+  // An existing config is merged into, never clobbered, and a present pair is kept.
+  await fs.writeFile(m43FolderFile, JSON.stringify({ year: 2026, month: 9, title: "September 2026", theme: { accent: "#7B5EA7" }, order: ["2026-09-03"] }));
+  await createPage(root, { chapter: "2026-09", name: "2026-09-01", template: "daily-minimal" });
+  m43Folder = JSON.parse(await fs.readFile(m43FolderFile, "utf8"));
+  check("existing .folder.json keys (title, theme) survive a create", m43Folder.title === "September 2026" && m43Folder.theme?.accent === "#7B5EA7" && m43Folder.year === 2026, JSON.stringify(m43Folder));
+  check("the new day lands first in chronological order", m43Folder.order[0] === "2026-09-01", JSON.stringify(m43Folder.order));
+  const m43DailyFolder = JSON.parse(await fs.readFile(path.join(root, "Shared", "Daily", ".folder.json"), "utf8"));
+  check("a non-month chapter is unchanged: title = chapter name, no year/month", m43DailyFolder.title === "Daily" && !("year" in m43DailyFolder), JSON.stringify(m43DailyFolder));
 
   console.log("\nread_ink strips bulky data-stroke streams by default");
   const inkSvgDoc =


### PR DESCRIPTION
Stacked on #53.

## Summary
- **#43** `createPage` stamps `year`+`month` when it mints a `YYYY-MM` chapter (merge, never clobber; **no** placeholder `title` so the app fills "September 2026") and inserts the page into `order` chronologically among dated siblings.
- **#44** `SHARED-VISUAL-SPEC.md` §1/§2 re-verified against catalogue 14: hour labels are per style (cozy/colorful print a 34px gutter → `gutterX`), and **no** shipped template prints checkboxes — `PRINTS_OWN_CHECKBOXES_RE` + `printed_checkboxes` retired; a smoke check audits the catalogue instead. Same facts corrected in `ON-DEVICE-UNDERLAY.md`/`MCP-INTEGRATION.md`; CLAUDE.md's renderer gotcha trued up to shipped `<tspan x/y/dy>` + `<g>` inheritance (onionskin#211/#212).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run smoke` — 385 passed, 0 failed (7 new checks: stamped pair, no title, chronological insert, merge preserves keys, catalogue checkbox audit, cozy marker no longer warns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEFvwptDc4jKCm5UXRK43k