### PR TITLE
feat: lines[].align, positioned <tspan>, typography warnings (#33 #42 #29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,8 +242,12 @@ pages, so catalogue instantiation is how the first page in a chapter gets made.
   (`RAW_SVG_ALLOWED_ELEMENTS` in `src/svg.ts` is the source of truth) and silently drops
   anything else. Since app build 121 (onionskin#212) a `<tspan>` carrying `x`/`y`/`dy` starts a
   new line inside one `<text>` (no per-run font/fill — a bare tspan still flattens into the
-  parent run with a space); this server's structured output keeps emitting stacked `<text>`
-  per line, and its raw-svg validator's tspan acceptance is tracked in #42. `font-family`,
+  parent run with a space); the raw-svg validator accepts `tspan` and warns
+  `raw_svg_tspan_attrs` / `raw_svg_tspan_unpositioned` for those two limits (#42), while
+  structured output keeps emitting stacked `<text>` per line (renders on every build).
+  Structured lines take `align: left|center|right` (#33), emitted as `text-anchor` per
+  `<text>`. Body copy under 13px warns `text_too_small`; Caveat/Fredoka body copy in a
+  planner region is info-flagged `handwriting_body_font` (#29). `font-family`,
   `font-size`, `font-weight`, `text-anchor` and `fill` now **inherit from a wrapping `<g>`**
   (onionskin#211 fixed; a value on the `<text>` wins) — older builds dropped the anchor/weight,
   so per-`<text>` attributes remain the safest form.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ write_underlay         → place text by region/row; server computes coordinates
 }
 ```
 
-`row` aligns to the region's ruled lines (from `read_page`). Use `y`/`x` for explicit
+`row` aligns to the region's ruled lines (from `read_page`); `align` (`left`/`center`/`right`)
+anchors a line against the region box. Use `y`/`x` for explicit
 placement, `marker` (`checkbox`/`bullet`) for a leading mark, and `time` to place
 a schedule line by the clock (anchored by the template's `data-start-hour`, or a per-call
 `startHour` override). For hand-placed content in a single region, give it a raw

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -217,6 +217,32 @@ past the grid, which would otherwise fold onto the last rule), and `text_below_r
 line whose baseline falls below the region box). Treat any of these as "re-layout", not noise —
 an unattended write has no human to notice the pile-up.
 
+### Font roles (#29)
+
+AI underlay copy is **clean UI type**; the handwriting faces belong to the user's ink layer.
+The defaults already do this — change them deliberately, not by habit:
+
+| Role | Face | Notes |
+|---|---|---|
+| Body copy — schedule, to-dos, `focus`, list items | **Mulish** 15 / 600 | the per-region default |
+| `ainotes` prose | **Newsreader** 15 / 500 | the serif AI voice |
+| Hour gutter / monospace data | IBM Plex Mono | printed by cozy/colorful templates |
+| Headings / banner labels | Mulish (or the theme's heading face) | 700–800 |
+| `Caveat` / `Fredoka` | **opt-in only** — `fontPersonality: "handwritten"` or a per-line `font` | reads as handwriting; body copy set in it is info-flagged `handwriting_body_font` |
+
+**Never below 13px** for body text (`text_too_small` warns; headings are exempt). The font set
+is closed — `Mulish`, `Newsreader`, `IBM Plex Mono`, `Caveat`, `Fredoka`, `Phosphor` — so a
+"Shantell Sans affirmation" isn't available; use Newsreader in `ainotes` for warmth instead.
+
+### Alignment (#33)
+
+A line's `align: "left" | "center" | "right"` anchors it against the region box from the
+template geometry — you never measure text. `center` emits `text-anchor="middle"` on the box's
+horizontal centre, `right` emits `text-anchor="end"` at the right inset; wrapped continuations
+share the anchor and a `heading` pill shifts with it. A leading `marker`/`icon` is only drawn
+on a left-aligned line (`align_marker_ignored`, info). Typical uses: a right-aligned date in the
+header, a centred label under a sticker, a right-aligned total.
+
 ## Use the placement the server already does for you
 
 - **Schedule by clock time, not coordinates.** Give each line a `time: "HH:MM"`; the server
@@ -288,33 +314,39 @@ silently dropped on device, so `write_underlay` warns `raw_svg_unsupported_eleme
 
 | Accepted | Rejected (warns) |
 |---|---|
-| `svg` `g` `rect` `line` `path` `text` `image` `circle` `ellipse` `polyline` `polygon` | everything else — notably `tspan`, `foreignObject`, `use`, `defs`, `style`, `clipPath`, `mask`, `filter`, `textPath` |
+| `svg` `g` `rect` `line` `path` `text` `tspan` `image` `circle` `ellipse` `polyline` `polygon` | everything else — notably `foreignObject`, `use`, `defs`, `style`, `clipPath`, `mask`, `filter`, `textPath` |
 
-**Attributes** — the split that costs the most trial-and-error is *what inherits*. The
-renderer resolves style per leaf element, not by cascading from ancestors:
+**Attributes — what inherits.** Since app build 121 the renderer cascades these five from
+a wrapping `<g>` (a value on the `<text>` wins): `font-family`, `font-size`, `font-weight`,
+`text-anchor`, `fill` ([onionskin#211](https://github.com/bsitkoff/onionskin/issues/211),
+fixed). Older builds dropped `text-anchor`/`font-weight` set only on the `<g>` (a centred
+block silently rendered left-aligned), so per-`<text>` attributes remain the safest form —
+and are what the structured `align` option emits.
 
-| Attribute | On `<text>` | On a wrapping `<g>` |
-|---|---|---|
-| `fill`, `fill-opacity`, `font-family`, `font-size` | works | **inherits** |
-| `text-anchor` (`middle` / `end`) | works | **dropped** — put it on each `<text>` |
-| `font-weight` (`400`–`800`) | works | **dropped** — put it on each `<text>` |
+**`<tspan>` — one multi-line `<text>` object.** Since build 121
+([onionskin#212](https://github.com/bsitkoff/onionskin/issues/212)) a `<tspan>` carrying
+`x`, `y` or `dy` starts a new line *inside one `<text>`*, and the whole block is **one**
+selectable/movable object in the app's underlay editor:
 
-The two "dropped" rows are app bug
-[onionskin#211](https://github.com/bsitkoff/onionskin/issues/211), still open as of
-2026-07-24 — a `text-anchor` set only on the `<g>` silently renders left-aligned, which can
-push centered content off-page. Set both per `<text>` until that lands.
+```xml
+<text x="24" y="30" font-family="Mulish" font-size="15" fill="#3B7BAD">First line
+  <tspan x="24" dy="20">second line</tspan>
+  <tspan x="24" dy="20">third</tspan></text>
+```
 
-Two more things worth knowing before you design around them:
+Two app-side limits, both surfaced by the validator:
 
-- **`<tspan>` is not a positioned element.** Multi-line text is authored as *stacked
-  `<text>` elements*, one per line — which is exactly what the structured `lines` input
-  (and its `wrap`) already emits. The validator rejects `<tspan>` outright.
-- **`<g>` is file-level grouping only — not a selectable object.** Wrapping several lines in
-  a `<g>` does *not* make them one movable unit in the app's editor: `AIEditModel`
-  hit-tests and selects at the leaf level (text or image), descending through groups. There
-  is currently no way to author one multi-line text object
-  ([onionskin#212](https://github.com/bsitkoff/onionskin/issues/212)).
-- `xml:space="preserve"` passes the validator but has no effect on the renderer.
+- **No per-line styling.** A tspan's `font-*`, `fill`, `text-anchor`, `dx`, `rotate` are
+  ignored — the `<text>`'s own attributes apply to every line (`raw_svg_tspan_attrs`).
+- **A bare `<tspan>` (no `x`/`y`/`dy`) is not a line break.** Its characters flatten into
+  the parent run with one inserted space (`raw_svg_tspan_unpositioned`, info).
+- Pages rendered by app builds **older than 121** flatten positioned tspans into one
+  space-joined line — no runtime gymnastics here, just know it.
+- A hand-edit in the app's "Edit underlay" collapses the runs to flat embedded-`\n` text.
+
+The structured `lines` input still emits stacked `<text>` per line (one per wrapped segment),
+which renders identically on every build; reach for tspans only when you want the block to be
+one object in the editor. `xml:space="preserve"` passes the validator but has no effect.
 
 ## Images (stickers / art)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,29 @@ roadmap holds only planned feature development (bugs/polish live on the
 
 ---
 
+## Feature: `align` on structured lines, positioned `<tspan>` accepted, typography warnings — 2026-08-20
+
+[#33](https://github.com/bsitkoff/onion_planner_mcp/issues/33),
+[#42](https://github.com/bsitkoff/onion_planner_mcp/issues/42),
+[#29](https://github.com/bsitkoff/onion_planner_mcp/issues/29). Centred/right-aligned text was
+unreachable through the structured API (only raw svg with hand-measured x), the validator still
+rejected the `<tspan x/y/dy>` the app has rendered since build 121, and nothing flagged 11px
+body copy or Caveat-set to-dos.
+
+- **`lines[].align: "left" | "center" | "right"`** — resolved against the region box and emitted
+  as `text-anchor="middle"|"end"` **per `<text>`** (renders on every app build); wrapped
+  continuations share the anchor, a banner heading's pill shifts with it, `text_overflow`
+  measures from the anchor. A marker/icon on an aligned line is skipped (`align_marker_ignored`,
+  info); a region with no width degrades to left (`align_unbounded_region`, info).
+- **`tspan` joins `RAW_SVG_ALLOWED_ELEMENTS`**; `scanRawSvgTspans` warns `raw_svg_tspan_attrs`
+  for per-run attributes the app ignores (anything but `x`/`y`/`dy`) and info-flags
+  `raw_svg_tspan_unpositioned` for a bare tspan (flattens with a space). Both raw-svg sites.
+- **`text_too_small`** (body `size < 13`) and **`handwriting_body_font`** (info, once per region:
+  Caveat/Fredoka body copy in a planner region — opt out with `fontPersonality: "clean"` or a
+  per-line `font`). `AUTHORING.md` gains "Font roles" + "Alignment"; the raw-SVG section is
+  rewritten to the shipped tspan / inheritance contract. Shantell Sans (asked for in #29) is not
+  in the closed font set and isn't added.
+
 ## Fix: minted month chapters carry `year`/`month`; spec re-verified (hour gutter, no printed checkboxes) — 2026-08-20
 
 [#43](https://github.com/bsitkoff/onion_planner_mcp/issues/43),

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,6 +320,15 @@ const lineSchema = z.object({
     .optional()
     .describe("Explicit baseline y, local to the region's top-left. Overrides `row`."),
   x: z.number().optional().describe("Local x offset from the region's left edge. Default 24."),
+  align: z
+    .enum(["left", "center", "right"])
+    .optional()
+    .describe(
+      "Horizontal alignment within the region box: 'left' (default) starts at the inset; " +
+        "'center' anchors on the box's horizontal centre; 'right' anchors at the right " +
+        "inset — resolved from the template geometry, so you never measure text. Wrapped " +
+        "continuations share the anchor; a leading marker/icon is only drawn when left-aligned.",
+    ),
   font: FONT_ENUM.optional().describe(
     "Font family. Defaults per region (Mulish; Newsreader for the serif ainotes block).",
   ),

--- a/src/page.ts
+++ b/src/page.ts
@@ -23,6 +23,7 @@ import {
   imageBox,
   scanRawSvgElements,
   scanRawSvgDataUriImages,
+  scanRawSvgTspans,
   extractRegionGroups,
   type RegionInput,
   type ImageInput,
@@ -1011,6 +1012,25 @@ function rawSvgWarnings(svg: string, size: [number, number]): {
       "raw_svg_unsupported_element",
       `raw svg uses unsupported element(s) for the app renderer: ${unsupported.join(", ")}.`,
     );
+  }
+
+  const tspans = scanRawSvgTspans(svg);
+  if (tspans.styled.length > 0) {
+    warn(
+      "raw_svg_tspan_attrs",
+      `raw svg <tspan> carries ${tspans.styled.join(", ")} — the app honours only x/y/dy on ` +
+        `a tspan; per-line font/fill/anchor is ignored (the <text>'s own attributes apply ` +
+        `to every line).`,
+    );
+  }
+  if (tspans.unpositioned > 0) {
+    warningDetails.push({
+      code: "raw_svg_tspan_unpositioned",
+      severity: "info",
+      message:
+        `raw svg has ${tspans.unpositioned} <tspan> without x/y/dy — not a line break; its ` +
+        `text flattens into the parent run with a space.`,
+    });
   }
 
   const vb = parseViewBox(svg);

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -38,6 +38,10 @@ export const RAW_SVG_ALLOWED_ELEMENTS = new Set([
   "ellipse",
   "polyline",
   "polygon",
+  // Since app build 121 (onionskin#212): a <tspan> carrying x/y/dy starts a new line
+  // inside ONE <text> (one selectable object in the app's underlay editor). See
+  // `scanRawSvgTspans` for the two limits the app keeps.
+  "tspan",
 ]);
 
 /** Element names used in `svg` that fall outside the renderer's set (sorted, unique). */
@@ -49,6 +53,36 @@ export function scanRawSvgElements(svg: string): string[] {
   }
   return [...unsupported].sort();
 }
+
+/** The only <tspan> attributes the app honours (onionskin#212). */
+const TSPAN_POSITION_ATTRS = new Set(["x", "y", "dy"]);
+
+/**
+ * What raw svg does with `<tspan>` that the app will NOT honour (#42):
+ * - `styled`: attribute names (other than `x`/`y`/`dy`) found on any tspan — the app
+ *   ignores per-run `font-*`/`fill`/`text-anchor`/`dx`/`rotate`; a `<text>`'s own
+ *   attributes apply to every line.
+ * - `unpositioned`: tspans carrying none of `x`/`y`/`dy` — these are not lines; their
+ *   characters flatten into the parent run with a separating space (app issue #72).
+ */
+export function scanRawSvgTspans(svg: string): { styled: string[]; unpositioned: number } {
+  const styled = new Set<string>();
+  let unpositioned = 0;
+  for (const m of svg.matchAll(/<\s*tspan\b([^>]*)>/gi)) {
+    const attrs = [...m[1].matchAll(/([A-Za-z_:][A-Za-z0-9_:.-]*)\s*=/g)].map((a) => a[1]);
+    const positioned = attrs.some((a) => TSPAN_POSITION_ATTRS.has(a.toLowerCase()));
+    if (!positioned) unpositioned++;
+    for (const a of attrs) if (!TSPAN_POSITION_ATTRS.has(a.toLowerCase())) styled.add(a);
+  }
+  return { styled: [...styled].sort(), unpositioned };
+}
+
+/** Fonts that read as the user's handwriting layer, not AI body copy (#29). */
+const HANDWRITING_FONTS = new Set(["Caveat", "Fredoka"]);
+/** Regions whose body copy is planner content (schedule/to-do/notes), not decoration. */
+const BODY_COPY_REGION_RE = /^(schedule|agenda|todo|list-\d+|ainotes|focus|notes|last)$/;
+/** Minimum legible body size for AI underlay text (#29). */
+const MIN_BODY_TEXT_SIZE = 13;
 
 /**
  * True when raw svg contains an <image href="data:..."> — the app renderer resolves
@@ -454,6 +488,15 @@ export interface LineInput {
   y?: number;
   /** Local x offset from the region's left edge. Defaults to 24. */
   x?: number;
+  /**
+   * Horizontal alignment within the region box (#33). `left` (default) starts the text
+   * at the inset `x`; `center` anchors it (`text-anchor="middle"`) on the box's
+   * horizontal centre; `right` anchors it (`text-anchor="end"`) at the box's right
+   * inset. Emitted per `<text>` (not on the wrapping `<g>`) so it renders on every
+   * app build; wrapped continuations share the anchor. A leading `marker`/`icon` is
+   * only drawn on a left-aligned line. Ignored in a region with no known width.
+   */
+  align?: "left" | "center" | "right";
   font?: string;
   size?: number;
   /** SVG font-weight (100–900). Defaults per region (600; 500 for the quote). */
@@ -1490,6 +1533,26 @@ export function composeAiSvg(
       // Raw fragment, emitted verbatim inside the region group (escape hatch).
       const frag = input.svg.trim();
       if (frag) {
+        const tspans = scanRawSvgTspans(frag);
+        if (tspans.styled.length > 0) {
+          warn(
+            "raw_svg_tspan_attrs",
+            `region "${region.name}": <tspan> carries ${tspans.styled.join(", ")} — the app ` +
+              `honours only x/y/dy on a tspan; per-line font/fill/anchor is ignored (the ` +
+              `<text>'s own attributes apply to every line).`,
+            "warning",
+            region.name,
+          );
+        }
+        if (tspans.unpositioned > 0) {
+          warn(
+            "raw_svg_tspan_unpositioned",
+            `region "${region.name}": ${tspans.unpositioned} <tspan> without x/y/dy — not a ` +
+              `line break; its text flattens into the parent run with a space.`,
+            "info",
+            region.name,
+          );
+        }
         const unsupported = scanRawSvgElements(frag);
         if (unsupported.length > 0) {
           warn(
@@ -1588,9 +1651,38 @@ export function composeAiSvg(
       const flowBases = flowBaselines(region, lines, def, theme);
       // baseline y -> the text of the `lines[]` entry that owns it (row_collision, #30).
       const baselineOwners = new Map<number, string>();
+      let handwritingWarned = false;
       lines.forEach((line, i) => {
         const size = line.size ?? def.size;
         const font = line.font ?? themeFontFor(theme, region.name, !!line.heading) ?? def.font;
+        // #29: AI body copy is clean UI type — ≥13px, and not a handwriting face (Caveat/
+        // Fredoka read as the user's ink layer). Both are advisory; an explicit per-line
+        // `font`/`size` or `fontPersonality: "handwritten"` still wins.
+        if (!line.heading && size < MIN_BODY_TEXT_SIZE) {
+          warn(
+            "text_too_small",
+            `region "${region.name}": line "${truncate(line.text)}" is ${size}px — body text ` +
+              `below ${MIN_BODY_TEXT_SIZE}px is hard to read on the iPad; use ≥${MIN_BODY_TEXT_SIZE}.`,
+            "warning",
+            region.name,
+          );
+        }
+        if (
+          !line.heading &&
+          !handwritingWarned &&
+          HANDWRITING_FONTS.has(font) &&
+          BODY_COPY_REGION_RE.test(region.name)
+        ) {
+          handwritingWarned = true;
+          warn(
+            "handwriting_body_font",
+            `region "${region.name}": body copy is set in ${font}, which reads as the user's ` +
+              `handwriting layer — AI planner content is clearest in Mulish (the default). ` +
+              `Pass \`fontPersonality: "clean"\` or a per-line \`font\` if this wasn't intended.`,
+            "info",
+            region.name,
+          );
+        }
         const weight = line.weight ?? def.weight;
         const fill = line.fill !== undefined ? floorTextFill(line.fill) : baseFill;
         // Inset at least past the template's printed hour-label gutter (#44).
@@ -1802,6 +1894,29 @@ export function composeAiSvg(
           }
         }
 
+        // Horizontal alignment (#33): resolved against the region box, emitted as
+        // `text-anchor` per <text> so the renderer measures — this server never does.
+        const xPadR = def.xPad ?? DEFAULT_X_PAD;
+        let align: "left" | "center" | "right" = line.align ?? "left";
+        if (align !== "left" && region.width === null) {
+          warn(
+            "align_unbounded_region",
+            `region "${region.name}": line "${truncate(line.text)}" asks for align "${align}" ` +
+              `but the region has no known width — drawn left-aligned.`,
+            "info",
+            region.name,
+          );
+          align = "left";
+        }
+        const anchorX =
+          align === "center"
+            ? Math.round(region.width! / 2)
+            : align === "right"
+              ? region.width! - xPadR
+              : x;
+        const anchorAttr =
+          align === "center" ? ' text-anchor="middle"' : align === "right" ? ' text-anchor="end"' : "";
+
         // A section heading. `banner` themes draw a coloured pill + white label
         // (cycling banner colours so sections read distinctly); `underline` themes
         // draw a coloured label + hairline rule (quieter). No marker/wrap — a label.
@@ -1810,26 +1925,28 @@ export function composeAiSvg(
           if (theme.headingStyle === "banner") {
             const labelW = bannerLabelWidth(line.text, size);
             const padX = BANNER_PAD_X;
+            const pillW = labelW + padX * 2;
+            const px = align === "center" ? anchorX - Math.round(pillW / 2) : align === "right" ? anchorX - pillW : x;
             const bh = Math.round(size * 1.15) + 6;
             const by = y - Math.round(size * 0.82) - 3;
             const color = line.fill ?? theme.banners[bannerIdx % theme.banners.length];
             bannerIdx++;
             const headText = pillLabelColor(color, line.fill !== undefined, region.name);
             parts.push(
-              `    <rect x="${x}" y="${by}" width="${labelW + padX * 2}" height="${bh}" ` +
+              `    <rect x="${px}" y="${by}" width="${pillW}" height="${bh}" ` +
                 `rx="6" fill="${color}"/>`,
             );
             parts.push(
-              `    <text x="${x + padX}" y="${y}" font-family="${escapeXml(font)}" ` +
+              `    <text x="${px + padX}" y="${y}" font-family="${escapeXml(font)}" ` +
                 `font-size="${size}" font-weight="${hWeight}" letter-spacing="0.08em" ` +
                 `fill="${headText}">${escapeXml(line.text)}</text>`,
             );
           } else {
             const hfill = line.fill !== undefined ? floorTextFill(line.fill) : theme.text;
             parts.push(
-              `    <text x="${x}" y="${y}" font-family="${escapeXml(font)}" ` +
-                `font-size="${size}" font-weight="${hWeight}" letter-spacing="0.08em" ` +
-                `fill="${hfill}">${escapeXml(line.text)}</text>`,
+              `    <text x="${anchorX}" y="${y}" font-family="${escapeXml(font)}" ` +
+                `font-size="${size}" font-weight="${hWeight}" letter-spacing="0.08em"` +
+                `${anchorAttr} fill="${hfill}">${escapeXml(line.text)}</text>`,
             );
             if (region.width !== null) {
               const rx2 = region.width - (def.xPad ?? DEFAULT_X_PAD);
@@ -1845,7 +1962,17 @@ export function composeAiSvg(
           return;
         }
 
-        if (line.marker) {
+        if ((line.marker || line.icon) && align !== "left") {
+          // A leading mark is measured from the text's START, which an anchored line
+          // doesn't know without font metrics — keep the server out of that business.
+          warn(
+            "align_marker_ignored",
+            `region "${region.name}": line "${truncate(line.text)}" has a ${line.marker ? "marker" : "icon"} ` +
+              `and align "${align}" — the mark is only drawn on left-aligned lines; skipped.`,
+            "info",
+            region.name,
+          );
+        } else if (line.marker) {
           const m = markerFragment(line.marker, x, y, size, line.fill ?? theme.accent);
           parts.push(`    ${m.svg}`);
           x += m.advance;
@@ -1864,17 +1991,28 @@ export function composeAiSvg(
             effLine.row === undefined &&
             effLine.y === undefined &&
             line.time === undefined);
-        const maxWidth = region.width !== null ? region.width - x : null;
+        // Available width is box-relative: from the inset to the right edge when
+        // left-aligned; symmetric about the centre; from the left inset to the anchor
+        // when right-aligned.
+        const maxWidth =
+          region.width === null
+            ? null
+            : align === "center"
+              ? region.width - 2 * xPadR
+              : align === "right"
+                ? anchorX - xPadR
+                : region.width - x;
         const segments =
           effWrap && maxWidth !== null && maxWidth > 0
             ? wrapText(line.text, font, size, maxWidth)
             : [line.text];
         const subPitch = Math.round(size * 1.3);
+        const textX = align === "left" ? x : anchorX;
         segments.forEach((seg, si) => {
           const sy = y + si * subPitch;
           parts.push(
-            `    <text x="${x}" y="${sy}" font-family="${escapeXml(font)}" ` +
-              `font-size="${size}" font-weight="${weight}" fill="${fill}">${escapeXml(seg)}</text>`,
+            `    <text x="${textX}" y="${sy}" font-family="${escapeXml(font)}" ` +
+              `font-size="${size}" font-weight="${weight}"${anchorAttr} fill="${fill}">${escapeXml(seg)}</text>`,
           );
         });
 
@@ -1897,13 +2035,17 @@ export function composeAiSvg(
 
         if (region.width !== null) {
           if (!effWrap) {
-            // Warn if the (unwrapped) text likely runs past the right edge.
-            const end = x + estimateTextWidth(line.text, font, size);
-            if (end > region.width) {
+            // Warn if the (unwrapped) text likely runs past an edge — measured from the
+            // anchor: a centred run spills both ways, a right-anchored run spills left.
+            const w = estimateTextWidth(line.text, font, size);
+            const start = align === "center" ? anchorX - w / 2 : align === "right" ? anchorX - w : x;
+            const end = start + w;
+            if (end > region.width || start < 0) {
               warn(
                 "text_overflow",
                 `region "${region.name}": line "${truncate(line.text)}" ` +
-                  `(~${end}px) may overflow the ${region.width}px region width.`,
+                  `(~${Math.round(w)}px${align !== "left" ? `, ${align}-aligned` : ""}) may ` +
+                  `overflow the ${region.width}px region width.`,
                 "warning",
                 region.name,
               );

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -1418,6 +1418,78 @@ async function main() {
   const cozyMarker = composeAiSvg([1024, 1366], [{ region: "todo", lines: [{ text: "Buy stamps", marker: "checkbox" }] }], cozyTodo, undefined, "daily-cozy");
   check("a checkbox marker on daily-cozy (formerly flagged) no longer warns", !cozyMarker.warningDetails.some((w) => w.code === "printed_checkboxes"), JSON.stringify(cozyMarker.warnings));
 
+  console.log("\n#33 align; #42 positioned <tspan>; #29 typography warnings");
+  const alignRead = await readPage(root, daily);
+  const anRegion = alignRead.regions.find((r) => r.name === "ainotes")!;
+  const aligned = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "ainotes", lines: [
+      { text: "Centered", align: "center", wrap: false },
+      { text: "Flush right", align: "right", wrap: false },
+      { text: "Plain left", wrap: false },
+      { text: "Marked", align: "right", marker: "checkbox", wrap: false },
+    ] }],
+  });
+  const alignGroup = regionGroup(aligned.aiSvg, "ainotes") ?? "";
+  const centerEl = alignGroup.match(/<text[^>]*>Centered<\/text>/)?.[0] ?? "";
+  const rightEl = alignGroup.match(/<text[^>]*>Flush right<\/text>/)?.[0] ?? "";
+  const leftEl = alignGroup.match(/<text[^>]*>Plain left<\/text>/)?.[0] ?? "";
+  check("align center emits text-anchor=middle at the box centre", centerEl.includes('text-anchor="middle"') && centerEl.includes(`x="${Math.round(anRegion.width! / 2)}"`), centerEl);
+  check("align right emits text-anchor=end at the right inset", rightEl.includes('text-anchor="end"') && Number(rightEl.match(/ x="(\d+)"/)?.[1]) === anRegion.width! - 24, rightEl);
+  check("a left line carries no text-anchor (unchanged output)", !leftEl.includes("text-anchor"), leftEl);
+  check("a marker on an aligned line is skipped with an info warning", aligned.warningDetails.some((w) => w.code === "align_marker_ignored" && w.severity === "info"), JSON.stringify(aligned.warnings));
+  check("aligned short lines do not trip text_overflow", !aligned.warningDetails.some((w) => w.code === "text_overflow"), JSON.stringify(aligned.warnings));
+  const wideRight = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "ainotes", lines: [{ text: "A right-aligned line far too long for this two-hundred-and-eighty-nine pixel box", align: "right", wrap: false }] }],
+  });
+  check("a right-aligned overlong line warns text_overflow (spills left)", wideRight.warningDetails.some((w) => w.code === "text_overflow"), JSON.stringify(wideRight.warnings));
+  const wrapCenter = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "ainotes", lines: [{ text: "A centred paragraph that is long enough to wrap onto several lines inside the notes box", align: "center" }] }],
+  });
+  const wrapCenterEls = [...(regionGroup(wrapCenter.aiSvg, "ainotes") ?? "").matchAll(/<text[^>]*text-anchor="middle"[^>]*>/g)];
+  check("wrapped continuations of a centred line share the anchor", wrapCenterEls.length > 1, String(wrapCenterEls.length));
+  const alignedHeading = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "ainotes", lines: [{ text: "Tomorrow", heading: true, align: "center" }, { text: "Pack bag" }] }],
+  });
+  check("an aligned heading composes (pill or anchored label)", (regionGroup(alignedHeading.aiSvg, "ainotes") ?? "").includes(">Tomorrow</text>"), JSON.stringify(alignedHeading.warnings));
+  const unbounded = composeAiSvg([1024, 1366], [{ region: "ruled", lines: [{ text: "x", align: "right" }] }], parseRegions('<svg viewBox="0 0 1024 1366" xmlns="http://www.w3.org/2000/svg"><g id="region-ruled" data-region="ruled" transform="translate(0,0)"><line x1="0" y1="40" x2="200" y2="40"/></g></svg>'));
+  check("align on a region with no width degrades to left with an info warning", unbounded.warningDetails.some((w) => w.code === "align_unbounded_region") && !unbounded.svg.includes("text-anchor"), JSON.stringify(unbounded.warnings));
+  // #42 — positioned <tspan> is accepted; styled / bare tspans warn.
+  const tspanOk = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "ainotes", svg: '<text x="24" y="30" font-family="Mulish" font-size="15" fill="#3b7bad">First line<tspan x="24" dy="20">second line</tspan><tspan x="24" dy="20">third</tspan></text>' }],
+  });
+  check("positioned <tspan x/dy> passes the raw-svg validator clean", !tspanOk.warningDetails.some((w) => w.code.startsWith("raw_svg_")), JSON.stringify(tspanOk.warnings));
+  const tspanStyled = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "ainotes", svg: '<text x="24" y="30">A<tspan x="24" dy="20" fill="#ff0000" font-weight="800">B</tspan></text>' }],
+  });
+  check("a tspan with fill/font-weight warns raw_svg_tspan_attrs (naming them)", tspanStyled.warningDetails.some((w) => w.code === "raw_svg_tspan_attrs" && w.message.includes("fill") && w.message.includes("font-weight")), JSON.stringify(tspanStyled.warnings));
+  const tspanBare = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    svg: '<svg viewBox="0 0 1024 1366" xmlns="http://www.w3.org/2000/svg"><text x="100" y="100">A<tspan>B</tspan></text></svg>',
+  });
+  check("a bare <tspan> (top-level raw svg) is info-flagged as unpositioned, not unsupported", tspanBare.warningDetails.some((w) => w.code === "raw_svg_tspan_unpositioned" && w.severity === "info") && !tspanBare.warningDetails.some((w) => w.code === "raw_svg_unsupported_element"), JSON.stringify(tspanBare.warningDetails));
+  // #29 — body text ≥13px, handwriting faces reserved for the user's ink.
+  const typo = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [
+      { region: "todo", lines: [{ text: "tiny", size: 11 }, { text: "scrawl", font: "Caveat" }, { text: "Label", heading: true, size: 11, font: "Caveat" }] },
+      { region: "header", lines: [{ text: "Thursday", font: "Caveat" }] },
+    ],
+  });
+  check("body text under 13px warns text_too_small", typo.warningDetails.filter((w) => w.code === "text_too_small").length === 1, JSON.stringify(typo.warnings));
+  check("Caveat body copy in todo is info-flagged handwriting_body_font (once per region)", typo.warningDetails.filter((w) => w.code === "handwriting_body_font").length === 1 && typo.warningDetails.find((w) => w.code === "handwriting_body_font")?.region === "todo", JSON.stringify(typo.warnings));
+  check("a heading, and Caveat in the header, are exempt", !typo.warningDetails.some((w) => w.code === "handwriting_body_font" && w.region === "header"), JSON.stringify(typo.warnings));
+  const cleanTypo = await writeUnderlay(root, daily, {
+    status: "ready", dryRun: true,
+    regions: [{ region: "todo", lines: [{ text: "Buy stamps", marker: "checkbox" }] }],
+  });
+  check("default Mulish 15 body text trips neither typography warning", !cleanTypo.warningDetails.some((w) => w.code === "text_too_small" || w.code === "handwriting_body_font"), JSON.stringify(cleanTypo.warnings));
+
   console.log("\n#43: minting a YYYY-MM chapter stamps year/month (no title); order is chronological");
   await createPage(root, { chapter: "2026-09", name: "2026-09-15", template: "daily-minimal" });
   const m43FolderFile = path.join(root, "Shared", "2026-09", ".folder.json");


### PR DESCRIPTION
Stacked on #54.

## Summary
- **#33** `lines[].align: left|center|right` — resolved against the region box, emitted as `text-anchor` per `<text>` (renders on every build); wrap/heading/`text_overflow` are anchor-aware. Marker on an aligned line → `align_marker_ignored` (info).
- **#42** `tspan` accepted by the raw-svg validator; `raw_svg_tspan_attrs` warns on per-run attributes the app ignores, `raw_svg_tspan_unpositioned` (info) on a bare tspan. AUTHORING's raw-SVG section rewritten to the shipped contract (incl. the <121 build note and `<g>` inheritance).
- **#29** `text_too_small` (<13px body) and `handwriting_body_font` (info, once per region). New "Font roles" subsection. Shantell Sans is not in the closed font set — not added.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run smoke` — 401 passed, 0 failed (16 new checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEFvwptDc4jKCm5UXRK43k