### PR TITLE
feat: image placement — fit:contain, flatten:paper, composition warnings (#47 #26 #27 #25 #28)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,13 @@ server has no network/generation. The app's renderer resolves `<image href>` onl
 **page-relative file path** (no data-URIs), so `page.ts:resolveImages` validates the bytes
 (magic vs `format`, 2MB cap), writes them to the page's **`media/ai/`** folder, and rewrites
 the `<image href="media/ai/…">` into the region group; `svg.ts:imageDims` reads intrinsic size
-(aspect-fills an omitted height). Placement is region-local via `corner`/`x`/`y`. When a
+(aspect-fills an omitted height). Placement is region-local via `corner`/`x`/`y`; sizing is
+best left to `fit: "contain"` (native aspect inside the image box, no margin, never flagged
+too-small — #47; `"region"` = the same with an 8px inset). `flatten: "paper"` composites a
+PNG's alpha onto the template's paper colour before the write (#26); an unflattened PNG with
+alpha is info-flagged `image_has_alpha`. Text whose band runs under a placed image warns
+`image_competes_with_text` (#27); a region with a printed art box that gets text but no image
+info-flags `art_slot_unfilled` (#25). When a
 region prints an illustration placeholder — the header's right-side banner box, tagged
 `<rect data-region="art-header" data-fill="ai">` since app catalogue `14-art-header-region`
 (onionskin#224), or an untagged dashed `stroke-dasharray` rect on pages frozen from the older

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -385,17 +385,48 @@ sending, or set `images[].maxDimension`). `notes` is
 `fill: ink` (handwriting) — at most a *tiny* corner mark there, never a sticker over the writing
 area.
 
+**Placement default: contain at native aspect, whitespace OK, never stretch or crop (#47).**
+The renderer scales an `<image>` to its *exact* box (no `preserveAspectRatio`), so the only
+way to distort art is to hand it a box of the wrong shape. The two warning-free paths:
+
+- **`fit: "contain"`** — the one to reach for. The server sizes the box from the region's image
+  box (the art slot when it has one) at the source's own proportions, no margin, no size-floor
+  warning. A 3:1 banner in a 300×104 slot comes out 300×100; a square sticker in it comes out
+  104×104. If the art is the "wrong" shape for the box, it is contained and *does not fill* —
+  that is the intended result. **Never invent an aspect gate** and reject valid art.
+- **`width` only, no `height`** — the server derives the height from the source aspect.
+
+The only thing to avoid is `width` + `height` that fight the source (`image_aspect_mismatch`,
+"will render STRETCHED"). `fit: "region"` is the same contain with an 8px inset.
+
 **A header banner goes in the header's art slot — let the server place it.** The daily
-templates print a dashed rounded box on the right of the `header` band as the banner-art
-drop-zone; `read_page` surfaces it as the region's **`artSlot`** ({x,y,width,height}, or null
-on templates with no such box — agenda/monthly/todo/reflection/blank). You don't compute
-coordinates for it: give the `header` region an `images` entry and the server places it *in the
-art slot* — `corner`/`fit: "region"` and the `imageFloor` all target the slot, not the full
-band. So `fit: "region"` fills the box (covering the dashed placeholder — otherwise it renders
-as an orphaned empty box under your banner), and a plain `width` with no `x`/`y` centers it in
-the slot. Don't invent an aspect requirement or stretch art to fill the band: omit `height` to
-keep native proportions — whitespace inside the slot is fine. The date/title text still lands
-in the full header band, clear of the art slot.
+templates print a rounded box on the right of the `header` band as the banner-art drop-zone
+(tagged `art-header` on the current catalogue; an untagged dashed rect on older pages);
+`read_page` surfaces it as the region's **`artSlot`** ({x,y,width,height}, or null on templates
+with no such box — agenda/monthly/todo/reflection/blank). You don't compute coordinates for it:
+give the `header` region an `images` entry and the server places it *in the art slot* —
+`corner`/`fit` and the `imageFloor` all target the slot, not the full band. Two compositions
+that work (#25, #28):
+
+- **Banner + date text.** `fit: "contain"` on the art, and the date as a `lines[]` entry (the
+  date text lands in the band, clear of the slot — see the header recipe under *Composer
+  parity*). Leaving the slot empty while writing text prints an orphaned dashed box under your
+  copy — the server info-flags `art_slot_unfilled`.
+- **One integrated date sticker.** When the art already carries the day/date (the strongest
+  planner look — a finished sticker, not text-plus-decoration), put it in the slot with
+  `fit: "contain"` and **write no separate date line** (`lines: []`). Don't mix both: a date
+  sticker next to a date string reads as fragmented.
+
+Decorative PNGs with transparency: pass **`flatten: "paper"`** when you want a finished opaque
+sticker (the common case); leave it off only when the paper is meant to show through. An
+unflattened PNG with real alpha is info-flagged `image_has_alpha`. A *baked-in* checkerboard is
+pixels, not alpha — it needs `knockout` first (below), then flatten.
+
+**`ainotes` is text-first (#27).** The prose starts at the top; a supporting sticker (a habit
+tracker, a small illustration) is a footer — `corner: "bottom-right"` (or `"bottom-left"`),
+sized so it doesn't rise into the paragraph. A sticker can fit the box geometrically and still
+steal the eye; the server warns `image_competes_with_text` when a line's band runs under an
+image — treat it as "move the sticker down, or shorten the note", not noise.
 
 **Filenames must resolve — a dangling `href` renders blank.** The server writes each image to
 `media/ai/<stem>.<ext>` (the `stem` is `images[].name` if you pass one, else a content hash) and
@@ -429,10 +460,10 @@ the server own the filename, not to guess a stem.
 `convert_to_webp`/`get_generated_webp_images` — onionskin rejects webp (that path is for
 WordPress). More detail in the project memory (`onionskin-image-gen-pipeline`).
 
-Two more knobs cut hand-computed sizing out of the loop: `images[].fit:"region"` sizes the
-display box to fit inside the region's own box (aspect-preserving contain, inset by `margin`)
-instead of you computing a `width` from `read_page` geometry — omit `width`/`height` entirely
-when you set it. `images[].maxDimension` downscales an over-large PNG source (re-encoded, not
+Two more knobs cut hand-computed sizing out of the loop: `images[].fit` (`"contain"` — native
+aspect inside the region's image box, no margin, the default choice; `"region"` — the same
+with an 8px inset) sizes the display box for you instead of you computing a `width` from
+`read_page` geometry — omit `width`/`height` entirely when you set it. `images[].maxDimension` downscales an over-large PNG source (re-encoded, not
 just resized on disk) so it clears the 1536px guideline / 2MB cap instead of you resizing it
 by hand first — PNG only; a JPEG over the limit still needs downscaling before sending.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,30 @@ roadmap holds only planned feature development (bugs/polish live on the
 
 ---
 
+## Feature: `fit:"contain"`, `flatten:"paper"`, and composition warnings for images — 2026-08-20
+
+[#47](https://github.com/bsitkoff/onion_planner_mcp/issues/47),
+[#26](https://github.com/bsitkoff/onion_planner_mcp/issues/26),
+[#27](https://github.com/bsitkoff/onion_planner_mcp/issues/27),
+[#25](https://github.com/bsitkoff/onion_planner_mcp/issues/25),
+[#28](https://github.com/bsitkoff/onion_planner_mcp/issues/28). Orchestrators invented aspect
+gates and stretched art because "contain at native aspect, whitespace OK" wasn't a first-class
+knob; transparent stickers rendered as scaffolding; a sticker could sit on the prose with no
+signal; and a header written with text only left the printed art box orphaned.
+
+- **`images[].fit: "contain"`** — aspect-preserving contain against the region's image box (the
+  art slot when present), no margin, never flagged `image_small_for_region`. `"region"` keeps its
+  8px inset. The fit guard now reads the image box, so a region whose only known box is its art
+  slot still fits.
+- **`images[].flatten: "paper"`** composites a PNG's alpha onto the template's paper colour
+  (`paperColorOf`) before the `media/ai/` write (info `image_flattened`); an unflattened PNG with
+  real alpha is info-flagged **`image_has_alpha`** (decode bounded at 4M px).
+- **`image_competes_with_text`** — a line's estimated band runs under a placed image in the same
+  region (once per image). **`art_slot_unfilled`** (info) — a region with a printed art box got
+  text but no image. `AUTHORING.md` gains the contain-by-default rule, the two header
+  compositions (banner + date / one integrated date sticker), and the `ainotes` text-first +
+  footer-sticker pattern.
+
 ## Feature: `align` on structured lines, positioned `<tspan>` accepted, typography warnings — 2026-08-20
 
 [#33](https://github.com/bsitkoff/onion_planner_mcp/issues/33),

--- a/src/index.ts
+++ b/src/index.ts
@@ -469,12 +469,24 @@ const imageSchema = z.object({
         "`fit: \"region\"` sizes inside.",
     ),
   fit: z
-    .literal("region")
+    .enum(["contain", "region"])
     .optional()
     .describe(
-      "Size the display box to fit inside the region's own box (aspect-preserving contain, " +
-        "inset by `margin`) instead of computing `width`/`height` yourself from read_page " +
-        "geometry. Mutually exclusive with `width`/`height` — omit both when set.",
+      "Size the display box from the region's own image box (the art slot when it has one) " +
+        "instead of computing `width`/`height` yourself. \"contain\" — THE DEFAULT CHOICE FOR " +
+        "DECORATIVE ART: native aspect, contained, no margin, whitespace inside the box is " +
+        "fine, never stretched/cropped, no size-floor warning. \"region\" — the same contain " +
+        "inset by `margin` (8). Never invent an aspect gate; if the art is the wrong shape " +
+        "for the box, contain it and let it not fill. Mutually exclusive with `width`/`height`.",
+    ),
+  flatten: z
+    .literal("paper")
+    .optional()
+    .describe(
+      "Composite a transparent PNG onto the page's paper colour before writing — the " +
+        "\"finished sticker on paper\" look. Use for generated watercolour/hand-drawn stickers " +
+        "and banners whose transparency (or baked-in checkerboard) would otherwise read as " +
+        "unfinished on device. Writes an opaque PNG; no-op for JPEG.",
     ),
   maxDimension: z
     .number()
@@ -518,10 +530,10 @@ const imageSchema = z.object({
   message: '`chromaColor` is required when knockout is "chroma".',
 }).refine((i) => i.knockout === "chroma" || (i.chromaColor === undefined && i.tolerance === undefined), {
   message: '`chromaColor`/`tolerance` only apply when knockout is "chroma".',
-}).refine((i) => i.fit !== "region" || (i.width === undefined && i.height === undefined), {
-  message: '`fit: "region"` computes width/height itself — omit both.',
-}).refine((i) => i.fit === "region" || i.width !== undefined, {
-  message: "`width` is required unless `fit` is \"region\".",
+}).refine((i) => i.fit === undefined || (i.width === undefined && i.height === undefined), {
+  message: '`fit` computes width/height itself — omit both.',
+}).refine((i) => i.fit !== undefined || i.width !== undefined, {
+  message: "`width` is required unless `fit` is set.",
 });
 
 server.tool(

--- a/src/page.ts
+++ b/src/page.ts
@@ -9,6 +9,7 @@ import {
   parseViewBox,
   inspectTemplate,
   PAPER_COLOR,
+  paperColorOf,
   type Region,
   type TemplateInfo,
 } from "./template.js";
@@ -545,6 +546,7 @@ async function resolveImages(
   geometry: Region[],
   dryRun: boolean,
   deps: ResolveImagesDeps = {},
+  paperColor: string = PAPER_COLOR,
 ): Promise<{ warnings: string[]; warningDetails: WarningDetail[] }> {
   const warnings: string[] = [];
   const warningDetails: WarningDetail[] = [];
@@ -558,11 +560,11 @@ async function resolveImages(
       if ((img.data === undefined) === (img.path === undefined)) {
         throw new Error(`image in region "${region.region}" needs exactly one of \`data\` (base64) or \`path\`.`);
       }
-      if (img.fit === "region") {
+      if (img.fit !== undefined) {
         if (img.width !== undefined || img.height !== undefined) {
           throw new Error(
-            `image in region "${region.region}": fit:"region" computes width/height from the ` +
-              "region's own box — don't also pass `width`/`height`.",
+            `image in region "${region.region}": fit:"${img.fit}" computes width/height from the ` +
+              "region's own image box — don't also pass `width`/`height`.",
           );
         }
       } else if (img.width === undefined || img.width <= 0) {
@@ -651,27 +653,76 @@ async function resolveImages(
       // A source still over the cap after its downscale throws here, exactly as before.
       if (deferSizeChecks) checkImageSize(buf, region.region, warnings, warningDetails);
 
+      // Transparency (#26). `flatten: "paper"` composites a PNG's alpha onto the page's
+      // paper colour so a generated sticker lands as finished art, not scaffolding. When
+      // NOT flattened, a PNG that carries real alpha is info-flagged once — fine when the
+      // paper is meant to show through, a trap when the model baked in a checkerboard.
+      // Decoding is bounded (≤ ALPHA_SCAN_MAX_PIXELS) so the scan never dominates a write.
+      if (format === "png") {
+        const px = dims.width * dims.height;
+        if (img.flatten === "paper") {
+          if (px > MAX_DECODE_PIXELS) {
+            throw new Error(
+              `image in region "${region.region}" is ${dims.width}×${dims.height} — over the ` +
+                `${MAX_DECODE_PIXELS}-pixel ceiling for flatten:"paper". Downscale it first (maxDimension).`,
+            );
+          }
+          let decoded;
+          try {
+            decoded = decodePng(buf);
+          } catch (e) {
+            throw new Error(`image in region "${region.region}": ${(e as Error).message}`);
+          }
+          if (pngHasAlpha(decoded)) {
+            buf = encodePng(flattenOntoColor(decoded, paperColor));
+            const message =
+              `region "${region.region}": image flattened onto the paper colour ${paperColor} ` +
+              `(opaque PNG written).`;
+            warnings.push(message);
+            warningDetails.push({ code: "image_flattened", severity: "info", region: region.region, message });
+          }
+        } else if (px <= ALPHA_SCAN_MAX_PIXELS) {
+          let hasAlpha = false;
+          try {
+            hasAlpha = pngHasAlpha(decodePng(buf));
+          } catch {
+            /* imageDims already validated the magic; an undecodable PNG just skips the scan */
+          }
+          if (hasAlpha) {
+            const message =
+              `region "${region.region}": PNG has transparency — fine if the paper is meant to ` +
+              `show through; for a finished opaque sticker pass flatten:"paper" (a baked-in ` +
+              `checkerboard needs knockout first — see docs/AUTHORING.md).`;
+            warnings.push(message);
+            warningDetails.push({ code: "image_has_alpha", severity: "info", region: region.region, message });
+          }
+        }
+      }
+
       let width: number;
       let height: number;
-      if (img.fit === "region") {
+      if (img.fit !== undefined) {
         const geo = geometryByName.get(region.region);
-        if (!geo || geo.width === null || geo.height === null) {
+        // Fit into the region's image box — the art slot (e.g. the header's banner box)
+        // when present, else the full region box (#45). A region whose only known box IS
+        // its art slot still fits (the guard reads the image box, not the region rect).
+        const fitBox = geo ? imageBox(geo) : null;
+        const bw = fitBox?.width ?? null;
+        const bh = fitBox?.height ?? null;
+        if (bw === null || bh === null || bw <= 0 || bh <= 0) {
           throw new Error(
-            `image in region "${region.region}": fit:"region" needs a region with a known box ` +
+            `image in region "${region.region}": fit:"${img.fit}" needs a region with a known box ` +
               `— no box geometry found for "${region.region}".`,
           );
         }
-        // Fit into the region's image box — the art slot (e.g. the header's banner box)
-        // when present, else the full region box (#45).
-        const fitBox = imageBox(geo);
-        const bw = fitBox.width ?? geo.width;
-        const bh = fitBox.height ?? geo.height;
-        const margin = img.margin ?? 8;
+        // "contain" = native aspect inside the box, whitespace OK, no inset (#47);
+        // "region" keeps its 8px inset.
+        const margin = img.margin ?? (img.fit === "contain" ? 0 : 8);
         const boxW = bw - margin * 2;
         const boxH = bh - margin * 2;
         if (boxW <= 0 || boxH <= 0) {
           throw new Error(
-            `image in region "${region.region}": fit:"region" box is too small for margin ` +
+            `image in region "${region.region}": fit:"${img.fit}" box is too small for margin ` +
               `${margin} (image box is ${bw}×${bh}).`,
           );
         }
@@ -729,6 +780,35 @@ async function resolveImages(
     }
   }
   return { warnings, warningDetails };
+}
+
+/** Upper bound on the pixels we'll decode just to *look* for alpha (info warning). */
+const ALPHA_SCAN_MAX_PIXELS = 4_000_000;
+
+/** True when any pixel is less than fully opaque. */
+function pngHasAlpha(img: { pixels: Uint8Array }): boolean {
+  const p = img.pixels;
+  for (let i = 3; i < p.length; i += 4) if (p[i] !== 255) return true;
+  return false;
+}
+
+/** Composite RGBA pixels onto an opaque hex colour (straight alpha, "over"). */
+function flattenOntoColor(
+  img: { width: number; height: number; pixels: Uint8Array },
+  hex: string,
+): { width: number; height: number; pixels: Uint8Array } {
+  const m = /^#?([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex.trim());
+  const bg = m ? [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)] : [255, 254, 251];
+  const src = img.pixels;
+  const out = new Uint8Array(src.length);
+  for (let i = 0; i < src.length; i += 4) {
+    const a = src[i + 3] / 255;
+    out[i] = Math.round(src[i] * a + bg[0] * (1 - a));
+    out[i + 1] = Math.round(src[i + 1] * a + bg[1] * (1 - a));
+    out[i + 2] = Math.round(src[i + 2] * a + bg[2] * (1 - a));
+    out[i + 3] = 255;
+  }
+  return { width: img.width, height: img.height, pixels: out };
 }
 
 /** Delete any file in `media/ai/` not referenced by an href in the final ai.svg. */
@@ -1125,7 +1205,14 @@ export async function writeUnderlay(
     // and fills each image's href, ahead of composeAiSvg.
     const templateSvg = await readIfExists(path.join(abs, "template.svg"));
     const regions = templateSvg ? parseRegions(templateSvg, manifest.template) : [];
-    const imageResult = await resolveImages(abs, opts.regions, regions, opts.dryRun ?? false, deps);
+    const imageResult = await resolveImages(
+      abs,
+      opts.regions,
+      regions,
+      opts.dryRun ?? false,
+      deps,
+      templateSvg ? paperColorOf(templateSvg) : PAPER_COLOR,
+    );
     const size = pageSize(manifest, templateSvg);
     const themeInput = await resolveThemeInput(abs, templateSvg, opts);
     const composed = composeAiSvg(size, opts.regions, regions, themeInput, manifest.template);

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -602,9 +602,20 @@ export interface ImageInput {
    * contain, inset by `margin`) instead of a caller-computed `width`/`height` —
    * resolved in `page.ts:resolveImages` once the region's geometry and the
    * image's intrinsic dimensions are both known. Mutually exclusive with
-   * `width`/`height`.
+   * `width`/`height`. `"contain"` is the frictionless default for decorative art
+   * (#47): the same aspect-preserving contain against the image box (the art slot
+   * when the region has one) with **no** margin and no size-floor warning — native
+   * proportions, whitespace inside the box is expected, nothing is stretched or
+   * cropped. `"region"` is the older spelling with an 8px inset.
    */
-  fit?: "region";
+  fit?: "region" | "contain";
+  /**
+   * Composite a transparent PNG onto the page's paper colour before writing it
+   * (#26) — the "finished sticker on paper" look. A generated sticker's alpha (or a
+   * baked-in checkerboard) otherwise reads as unfinished scaffolding on device. The
+   * written file is an opaque PNG. No-op for JPEG (no alpha).
+   */
+  flatten?: "paper";
   /**
    * Downscale the source (PNG only) so neither dimension exceeds this, before
    * sizing/hashing/writing — resolved in `page.ts:resolveImages`. Use instead of
@@ -1444,10 +1455,13 @@ export function composeAiSvg(
         );
       }
     }
-    // Images paint first (background); text/calendar lands on top.
+    // Images paint first (background); text/calendar lands on top. Their region-local
+    // rects are kept so the text pass can flag a line that runs under one (#27).
+    const imageRects: Array<Bbox & { flagged: boolean }> = [];
     for (const img of input.images ?? []) {
       if (!img.href || !img.width || !img.height) continue;
       const { x, y } = placeImage(region, img);
+      imageRects.push({ x, y, w: img.width, h: img.height, flagged: false });
       const op = img.opacity !== undefined ? ` opacity="${img.opacity}"` : "";
       parts.push(
         `    <image href="${escapeXml(img.href)}" x="${x}" y="${y}" ` +
@@ -1473,7 +1487,9 @@ export function composeAiSvg(
       const centered =
         img.x === undefined && img.y === undefined && (img.corner === undefined || img.corner === "center");
       const floor = imageSizeFloor(region);
-      if (centered && floor && img.width < floor.width && img.height < floor.height) {
+      // A `fit` image was sized against the box on purpose (native aspect, contained) —
+      // that's the good case, never "too small" (#47).
+      if (centered && img.fit === undefined && floor && img.width < floor.width && img.height < floor.height) {
         const guidance = floor.interactive
           ? `content the user interacts with (a habit tracker) needs real size (~${INTERACTIVE_IMAGE_FLOOR}px tall to pencil-check)`
           : "size it toward the box, or corner-place it if it's meant as a small accent";
@@ -1523,6 +1539,19 @@ export function composeAiSvg(
           );
         }
       }
+    }
+    // The template prints an art placeholder here and this write fills the region with
+    // text but no image — the dashed box ships empty under/next to the copy (#25). Info:
+    // an orchestrator that meant "no banner today" can ignore it.
+    if (region.artSlot && imageRects.length === 0 && (input.lines?.length ?? 0) > 0) {
+      warn(
+        "art_slot_unfilled",
+        `region "${region.name}": the template prints a ${region.artSlot.width}×${region.artSlot.height} ` +
+          `art box here and nothing fills it — the dashed placeholder will show. Give this ` +
+          `region an \`images\` entry (fit:"contain") or accept the empty box.`,
+        "info",
+        region.name,
+      );
     }
     // Whether the `showHours` gutter actually reached the page. `showHours` on its own is
     // a legitimate write, so it has to count toward "drew something" below — but only when
@@ -2015,6 +2044,27 @@ export function composeAiSvg(
               `font-size="${size}" font-weight="${weight}"${anchorAttr} fill="${fill}">${escapeXml(seg)}</text>`,
           );
         });
+
+        // Text running under a placed image reads as competition, not composition
+        // (#27) — a sticker can fit the box geometrically and still sit on the prose.
+        // Flag each image once, against the line's estimated band.
+        if (imageRects.length > 0) {
+          const bandW = segments.reduce((m, s) => Math.max(m, estimateTextWidth(s, font, size)), 0);
+          const bandX = align === "center" ? anchorX - bandW / 2 : align === "right" ? anchorX - bandW : textX;
+          const band: Bbox = { x: bandX, y: y - size, w: bandW, h: size * 0.3 + (segments.length - 1) * subPitch + size };
+          for (const r of imageRects) {
+            if (r.flagged || !bboxesOverlap(band, r)) continue;
+            r.flagged = true;
+            warn(
+              "image_competes_with_text",
+              `region "${region.name}": line "${truncate(line.text)}" runs under the ` +
+                `${r.w}×${r.h} image at (${r.x},${r.y}) — keep text first and anchor a ` +
+                `supporting sticker in a free corner (e.g. corner:"bottom-right").`,
+              "warning",
+              region.name,
+            );
+          }
+        }
 
         // A single-segment line whose baseline (+ descender) sits below the region box
         // is drawn into whatever lies underneath — 40 flow lines into a 422px box used to

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -1634,6 +1634,53 @@ async function main() {
   const okHref = await writeUnderlay(root, hdrPage, { status: "ready", dryRun: true, regions: [{ region: "todo", images: [{ data: PNG_1x1, format: "png", name: "real", width: 40 }] }] });
   check("a resolved structured image does not warn image_href_missing", !okHref.warningDetails.some((w) => w.code === "image_href_missing"), JSON.stringify(okHref.warningDetails));
 
+  console.log("\n#47 fit:\"contain\"; #26 flatten:\"paper\" + image_has_alpha; #27 image_competes_with_text; #25 art_slot_unfilled");
+  const hdrRegions = (await readPage(root, hdrPage)).regions;
+  const hdrArt = hdrRegions.find((r) => r.name === "header")!.artSlot!;
+  const widePixels = new Uint8Array(60 * 20 * 4).fill(200);
+  for (let i = 3; i < widePixels.length; i += 4) widePixels[i] = 255; // opaque
+  const wideSrc = encodePng({ width: 60, height: 20, pixels: widePixels }).toString("base64");
+  const contain = await writeUnderlay(root, hdrPage, { status: "ready", dryRun: true, regions: [{ region: "header", images: [{ data: wideSrc, format: "png", name: "wide", fit: "contain" }] }] });
+  const containImg = (regionGroup(contain.aiSvg, "header") ?? "").match(/<image[^>]*>/)?.[0] ?? "";
+  const cW = Number(containImg.match(/width="(\d+)"/)?.[1]);
+  const cH = Number(containImg.match(/height="(\d+)"/)?.[1]);
+  const cX = Number(containImg.match(/ x="(-?\d+)"/)?.[1]);
+  check("fit:contain sizes a 3:1 source to the art slot's full width at native aspect (300×100)", cW === hdrArt.width && cH === Math.round(hdrArt.width / 3), containImg);
+  check("fit:contain centres the box in the art slot (no margin)", cX === hdrArt.x, containImg);
+  check("fit:contain emits no size-floor / aspect / overflow warning (the good case)", !contain.warningDetails.some((w) => ["image_small_for_region", "image_aspect_mismatch", "image_overflow"].includes(w.code)), JSON.stringify(contain.warnings));
+  const fitRegionW = Number(((regionGroup((await writeUnderlay(root, hdrPage, { status: "ready", dryRun: true, regions: [{ region: "header", images: [{ data: wideSrc, format: "png", name: "wide", fit: "region" }] }] })).aiSvg, "header") ?? "").match(/<image[^>]*width="(\d+)"/) ?? [])[1]);
+  // With the 8px inset the 3:1 source is height-bound: (104-16) × 3 = 264, not 284.
+  check("fit:region keeps its 8px inset (height-bound 3:1 → 264 wide)", fitRegionW === Math.min(hdrArt.width - 16, (hdrArt.height - 16) * 3), String(fitRegionW));
+  let fitRejected = false;
+  try { await writeUnderlay(root, hdrPage, { status: "ready", dryRun: true, regions: [{ region: "header", images: [{ data: wideSrc, format: "png", fit: "contain", width: 100 } as any] }] }); } catch { fitRejected = true; }
+  check("fit:contain + width is rejected (fit computes both)", fitRejected);
+  // #26 — a half-transparent PNG: flattened onto paper when asked, info-flagged when not.
+  const alphaPixels = new Uint8Array(20 * 10 * 4);
+  for (let i = 0; i < alphaPixels.length; i += 4) { alphaPixels[i] = 40; alphaPixels[i + 1] = 80; alphaPixels[i + 2] = 160; alphaPixels[i + 3] = i < alphaPixels.length / 2 ? 0 : 255; }
+  const alphaSrc = encodePng({ width: 20, height: 10, pixels: alphaPixels }).toString("base64");
+  const flat = await writeUnderlay(root, hdrPage, { status: "ready", regions: [{ region: "ainotes", images: [{ data: alphaSrc, format: "png", name: "sticker", width: 100, flatten: "paper", corner: "bottom-right" }] }] });
+  check("flatten:paper info-flags image_flattened", flat.warningDetails.some((w) => w.code === "image_flattened" && w.severity === "info"), JSON.stringify(flat.warningDetails));
+  const flatFile = (await fs.readdir(path.join(root, hdrPage, "media", "ai"))).find((f) => f.startsWith("sticker"))!;
+  const flatPng = decodePng(await fs.readFile(path.join(root, hdrPage, "media", "ai", flatFile)));
+  let opaque = true; let paperish = false;
+  for (let i = 3; i < flatPng.pixels.length; i += 4) if (flatPng.pixels[i] !== 255) opaque = false;
+  if (flatPng.pixels[0] > 240 && flatPng.pixels[1] > 240 && flatPng.pixels[2] > 240) paperish = true;
+  check("the written file is fully opaque, transparent pixels now paper-coloured", opaque && paperish, `alpha ok=${opaque} first px=${[flatPng.pixels[0], flatPng.pixels[1], flatPng.pixels[2]]}`);
+  check("flattened output does not also warn image_has_alpha", !flat.warningDetails.some((w) => w.code === "image_has_alpha"), JSON.stringify(flat.warnings));
+  const notFlat = await writeUnderlay(root, hdrPage, { status: "ready", dryRun: true, regions: [{ region: "ainotes", images: [{ data: alphaSrc, format: "png", name: "sticker", width: 100, corner: "bottom-right" }] }] });
+  check("an unflattened transparent PNG is info-flagged image_has_alpha", notFlat.warningDetails.some((w) => w.code === "image_has_alpha" && w.severity === "info"), JSON.stringify(notFlat.warnings));
+  check("an opaque PNG is not flagged image_has_alpha", !contain.warningDetails.some((w) => w.code === "image_has_alpha"), JSON.stringify(contain.warnings));
+  // #27 — text running under a centred sticker competes; a footer-anchored one doesn't.
+  const compete = await writeUnderlay(root, hdrPage, { status: "ready", dryRun: true, regions: [{ region: "ainotes", images: [{ data: wideSrc, format: "png", name: "big", width: 240 }], lines: Array.from({ length: 8 }, (_, i) => ({ text: `Note line ${i} with a few words in it`, wrap: false })) }] });
+  check("text under a centred image warns image_competes_with_text (once per image)", compete.warningDetails.filter((w) => w.code === "image_competes_with_text").length === 1, JSON.stringify(compete.warnings));
+  const footer = await writeUnderlay(root, hdrPage, { status: "ready", dryRun: true, regions: [{ region: "ainotes", images: [{ data: wideSrc, format: "png", name: "small", width: 90, corner: "bottom-right" }], lines: [{ text: "Short note" }, { text: "Second line" }] }] });
+  check("text-first + bottom-right supporting sticker does not compete", !footer.warningDetails.some((w) => w.code === "image_competes_with_text"), JSON.stringify(footer.warnings));
+  // #25 — a header filled with text but no art leaves the printed box empty: info.
+  const textOnlyHdr = await writeUnderlay(root, hdrPage, { status: "ready", dryRun: true, regions: [{ region: "header", lines: [{ text: "Thursday, August 20" }] }] });
+  check("header text with no image info-flags art_slot_unfilled", textOnlyHdr.warningDetails.some((w) => w.code === "art_slot_unfilled" && w.severity === "info"), JSON.stringify(textOnlyHdr.warnings));
+  check("a header with a banner does not flag art_slot_unfilled", !contain.warningDetails.some((w) => w.code === "art_slot_unfilled"));
+  check("a region with no art slot never flags art_slot_unfilled", !footer.warningDetails.some((w) => w.code === "art_slot_unfilled"));
+
   console.log("\nwrite_underlay images via local file `path` (no base64 through context)");
   const srcPng = path.join(os.tmpdir(), "onionskin-smoke-src.png");
   await fs.writeFile(srcPng, Buffer.from(PNG_1x1, "base64"));


### PR DESCRIPTION
Stacked on #55.

## Summary
- **#47** `images[].fit: "contain"` — native aspect inside the region's image box (art slot when present), no margin, never flagged too-small; `"region"` keeps its 8px inset. Fit guard reads the image box, so an art-slot-only region still fits. AUTHORING: "contain, don't stretch/crop, whitespace OK" is now the documented default; never invent an aspect gate.
- **#26** `images[].flatten: "paper"` composites PNG alpha onto the template's paper colour before the `media/ai/` write (`image_flattened` info); unflattened PNGs with alpha are info-flagged `image_has_alpha` (decode bounded at 4M px).
- **#27** `image_competes_with_text` when a line's band runs under a placed image (once per image); text-first + footer-sticker pattern documented.
- **#25/#28** `art_slot_unfilled` (info) when a region with a printed art box gets text but no image; the two header compositions (banner + date, or one integrated date sticker with no date text) documented.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run smoke` — 416 passed, 0 failed (15 new checks incl. a written flattened PNG decoded back as fully opaque)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEFvwptDc4jKCm5UXRK43k