### PR TITLE
feat: composer parity — habits, region vocab, plain labels, header clearance, parity guard (#50 #49 #48 #41 #51)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,11 +76,12 @@ to exercise the MCP transport itself.
 | `src/color.ts` | Pure colour helpers (hex↔HSL, hex↔OKLab) + `harmony` palette derivation from the template's sampled colours, with a lightness floor on derived text so it reads on cream. The underlay lift (`liftForUnderlay = 0.14`) steps **OKLCH lightness** (perceptual); `monthlyInks` holds the 12 confirmed per-month palettes. No deps. |
 | `src/page.ts` | Read a page, **atomic** ai.svg + `media/ai/` image writes (`resolveImages`/`gcOrphanMedia`), manifest status flips, `create_page`. |
 
-The 10 tools (all in `src/index.ts`): `get_library`, `list_pages`, `read_page`, `read_ink`,
+The 11 tools (all in `src/index.ts`): `get_library`, `list_pages`, `read_page`, `read_ink`,
 `write_underlay`, `set_underlay_status`, `clear_underlay`, `create_page`, `set_chapter_theme`,
-`fetch_image`. Only five mutate the library (`write_underlay`, `set_underlay_status`,
-`clear_underlay`, `create_page`, and `set_chapter_theme` — which writes only the chapter's
-`.folder.json → theme` block); `read_ink` is read-only (the user's handwriting layer — read it before composing
+`set_habits`, `fetch_image`. Only six mutate the library (`write_underlay`, `set_underlay_status`,
+`clear_underlay`, `create_page`, `set_chapter_theme` — which writes only the chapter's
+`.folder.json → theme` block — and `set_habits`, which writes only the root `settings.json →
+underlayHabits` key, read-modify-write, every other key preserved, refusing a garbled file); `read_ink` is read-only (the user's handwriting layer — read it before composing
 so you place AI content *around* a `shared` region's handwriting; bulky per-stroke `data-stroke`
 streams are stripped unless `includeStrokeData` is set; refuses when the chapter marks its ink
 private via `permissions.inkReadable: false`, reflection chapters private by default) and `fetch_image` only writes a
@@ -202,7 +203,8 @@ pages, so catalogue instantiation is how the first page in a chapter gets made.
   and the page's **`media/ai/`** subfolder (AI-owned images — written + garbage-collected
   here); on create, the new page's own files + the chapter `.folder.json` order; and via
   `set_chapter_theme`, the chapter `.folder.json → theme` block (only the passed keys, order +
-  other fields preserved). Never touch
+  other fields preserved); and via `set_habits`, the root `settings.json → underlayHabits` key
+  only (the app's `UNDERLAY-AUTOFILL.md` names it MCP read/writable). Never touch
   `ink.svg`, `stickers.svg`, `template.svg`, the rest of `media/`, or anything under `Private/`.
 - All writes go through `resolvePageRel` (enforces `Shared/` containment) and `atomicWrite`
   (temp + rename).

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ lighter than the user's ink and contrast-floored) — gold is retired.
 | `clear_underlay` | write | Reset ai.svg to empty + status `empty`. |
 | `create_page` | write | New shared page from a sibling's template, or from the `Templates/` catalogue by id. |
 | `set_chapter_theme` | write | Set a chapter's default theme (`.folder.json → theme`): `paletteCharacter`, explicit `accent`, `customInk1/2`, `harmony`/`varietyDial`/`fontPersonality`, `displayName`. Only the passed keys change; page order is preserved. `write_underlay` applies it as the default, `read_page` surfaces it. |
+| `set_habits` | write | Set the library's daily habit list (`settings.json → underlayHabits` — the one settings key this server writes; every other key preserved). Both the app's on-device composer and a `{ region: "habits", habits: true }` entry draw it as a vector checkbox block. `[]` clears. |
 | `fetch_image` | helper | Download an HTTPS PNG/JPEG to an `onionskin-fetch/` folder under the **OS temp dir** (`$TMPDIR` on macOS — not `/tmp`) and return a local path for `images[].path`; optional background removal requires `rembg`. |
 
 ### Typical flow

--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -217,6 +217,32 @@ past the grid, which would otherwise fold onto the last rule), and `text_below_r
 line whose baseline falls below the region box). Treat any of these as "re-layout", not noise —
 an unattended write has no human to notice the pile-up.
 
+### Composer parity: habits, section titles, the header (#48, #49, #50)
+
+The app's on-device composer is the *other* author of `ai.svg`; where it has a fixed look,
+match it so a device-authored day and an MCP-authored day read the same.
+
+- **Habits** are a vector block, never a raster sticker. The list lives in the library's
+  `settings.json → underlayHabits` (see `get_library` / `read_page`; set it with
+  `set_habits`). Draw it with `{ region: "habits", habits: true }` — one 13px square + the
+  name per row (Mulish 14, 21px pitch), titled "HABITS" through the region's `label-habits`
+  slot when the template prints one. It belongs in a region named `habits` (the composer
+  renders habits only there); on a template without one, `habits_region_name` info-flags the
+  detour. Never infer habits from to-dos or merge them into the to-do list.
+- **Section titles** go into the printed `label-*` slot (`labelSlot` on `read_page`). The
+  region's `label` already targets the slot; `labelStyle: "plain"` draws it exactly as the
+  composer does (uppercase Mulish 12/700, accent, no pill). Mind the slot names on the todo
+  template: columns are `list-1/2/3`, slots are `label-list1/2/3` (no hyphen) — `read_page`
+  resolves each region's own slot, so never derive one name from the other.
+- **The `accent` pocket** (every template) is one small sticker or tiny drawing — never text
+  (`accent_text` warns), and fine to leave empty.
+- **Header recipe** (the composer's geometry): date as `EEEE, MMMM d` at size 38 / weight 700
+  (28 on a header under 80px tall), then an optional uppercased one-line "story eyebrow" at
+  size 14 / weight 700 in the accent above it; art fills the `art-header` slot with
+  `fit: "contain"`. When art is present the server clamps header text to clear the slot by
+  12px, so the date never runs under the banner. Or skip the text entirely for a one-piece
+  date sticker (above).
+
 ### Font roles (#29)
 
 AI underlay copy is **clean UI type**; the handwriting faces belong to the user's ink layer.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,34 @@ roadmap holds only planned feature development (bugs/polish live on the
 
 ---
 
+## Feature: composer parity — habits block + `set_habits`, region vocab, plain labels, header clearance, parity guard — 2026-08-21
+
+[#50](https://github.com/bsitkoff/onion_planner_mcp/issues/50),
+[#49](https://github.com/bsitkoff/onion_planner_mcp/issues/49),
+[#48](https://github.com/bsitkoff/onion_planner_mcp/issues/48),
+[#41](https://github.com/bsitkoff/onion_planner_mcp/issues/41),
+[#51](https://github.com/bsitkoff/onion_planner_mcp/issues/51). Habit trackers were hand-placed
+raster stickers (broken hrefs, black boxes), the universal `accent` region and the rest of the
+2026-06 family fell to fallback typography, section titles didn't match the device composer,
+header text could run under the banner, and the hand-mirrored app tables had no drift check.
+
+- **`set_habits`** (11th tool) writes `settings.json → underlayHabits` — the one settings key
+  this server writes (read-modify-write, other keys preserved, garbled file refused);
+  `get_library`/`read_page` surface it. **`regions[].habits: true | string[]`** draws the
+  composer's vector block (13px `rx 2` square at x+6, Mulish 14 at x+26, baseline 18, pitch 21,
+  `habits_overflow`), self-titled "HABITS" through a `label-habits` slot. The catalogue
+  `habits` region itself ships from the app side (onionskin#225).
+- **Region vocab:** `accent` (+ `accent_text` warning), `habits`, `list-1/2/3`, `last`,
+  `photos`, `morning/afternoon/evening`, `weekdays`, `page`, `joys/concerns/memories` added to
+  `REGION_DEFAULTS`; `accent`/`habits` to `FILL_BY_NAME`.
+- **`labelStyle: "plain"`** — the composer's `sectionLabel` look (uppercase Mulish 12/700 in the
+  accent at the slot origin). **Header clearance:** with art in the slot, header text wraps to
+  `artSlot.x − 12`.
+- **`test/parity.ts`** (run by `npm run smoke`, skips without `../onionskin`): Phosphor
+  codepoints vs `Phosphor.swift`, catalogue regions/fills vs `FILL_BY_NAME`/`REGION_DEFAULTS`,
+  `RAW_SVG_ALLOWED_ELEMENTS` vs `SVGParser.swift`, `FONT_FAMILIES` (now exported from `svg.ts`,
+  the source of `FONT_ENUM`) vs the bundled `.ttf`s.
+
 ## Feature: `fit:"contain"`, `flatten:"paper"`, and composition warnings for images — 2026-08-20
 
 [#47](https://github.com/bsitkoff/onion_planner_mcp/issues/47),

--- a/docs/MCP-INTEGRATION.md
+++ b/docs/MCP-INTEGRATION.md
@@ -52,7 +52,7 @@ That `Documents/` directory is the **library root**. Layout:
 
 ```
 Documents/                         ← library root
-├─ settings.json                   ← global settings (read-only for you)
+├─ settings.json                   ← global settings (read `underlayVoice`; `underlayHabits` is the ONE key you may write)
 ├─ Templates/                      ← catalogue of templates (read-only; create_page source)
 │  ├─ templates.json               ← id/name/category/style/files per template
 │  └─ daily-minimal/template.svg   ← one folder per template id

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -106,8 +106,10 @@ instead of memorizing "don't double-write the date" in skill prose —
   What unblocking needs is the **legacy codepoint** for each new glyph, not just its SF Symbol
   name — the MCP addresses a glyph by codepoint, and the app's `legacyScalar` is `private`.
   (The app's exhaustive switches do force a codepoint to *exist* for any new case; nothing
-  forces it to be published or to match our mirror — see
-  [#41](https://github.com/bsitkoff/onion_planner_mcp/issues/41).)
+  forces it to be published — but since 2026-08-21 `npm run smoke` runs `test/parity.ts`, which
+  diffs our mirror against `Phosphor.swift` and lists unmirrored app glyphs, so the five landing
+  would surface in CI — [#41](https://github.com/bsitkoff/onion_planner_mcp/issues/41) /
+  [#51](https://github.com/bsitkoff/onion_planner_mcp/issues/51), shipped.)
   [#11](https://github.com/bsitkoff/onion_planner_mcp/issues/11)
 - **Full-text / handwriting search** (`textContains` on `list_pages`) — needs the app-side
   OCR data source; the where-does-recognized-text-live decision is recorded in the issue.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "tsx src/index.ts",
     "call": "tsx test/cli.ts",
     "build": "tsc",
-    "smoke": "rm -rf /tmp/onionskin-test && cp -R ../onionskin/Onionskin/Fixtures/Library /tmp/onionskin-test && ONIONSKIN_CONTAINER=/tmp/onionskin-test tsx test/smoke.ts"
+    "smoke": "rm -rf /tmp/onionskin-test && cp -R ../onionskin/Onionskin/Fixtures/Library /tmp/onionskin-test && ONIONSKIN_CONTAINER=/tmp/onionskin-test tsx test/smoke.ts && tsx test/parity.ts",
+    "parity": "tsx test/parity.ts"
   },
   "author": "Bridget Sitkoff",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import {
   listChapters,
   listPageRows,
   readUnderlayVoice,
+  readUnderlayHabits,
+  writeUnderlayHabits,
   LibraryMissingError,
 } from "./library.js";
 import {
@@ -19,7 +21,7 @@ import {
   writeChapterTheme,
   fetchImageToTemp,
 } from "./page.js";
-import { PHOSPHOR_CODEPOINTS } from "./svg.js";
+import { PHOSPHOR_CODEPOINTS, FONT_FAMILIES } from "./svg.js";
 import { PALETTE_CHARACTERS } from "./color.js";
 
 const PALETTE_CHARACTER_IDS = Object.keys(PALETTE_CHARACTERS) as [string, ...string[]];
@@ -61,7 +63,8 @@ server.tool(
       const root = await requireLibrary();
       const chapters = await listChapters(root);
       const underlayVoice = await readUnderlayVoice(root);
-      return json({ root, exists: true, sharedChapters: chapters, underlayVoice });
+      const underlayHabits = await readUnderlayHabits(root);
+      return json({ root, exists: true, sharedChapters: chapters, underlayVoice, underlayHabits });
     } catch (e: any) {
       if (e instanceof LibraryMissingError) {
         return {
@@ -69,6 +72,33 @@ server.tool(
           isError: true as const,
         };
       }
+      return { ...text(`Error: ${e.message}`), isError: true as const };
+    }
+  },
+);
+
+// --- set_habits ---
+server.tool(
+  "set_habits",
+  "Set the library's daily habit list — `settings.json → underlayHabits`, the explicit " +
+    "synced source both the app's on-device composer and this server's `habits` region " +
+    "block read (one square checkbox per habit; never inferred from reminders, never merged " +
+    "into to-dos). Read-modify-write of that ONE key; every other settings key is preserved. " +
+    "An empty list removes the key (no habits block). The file rides iCloud, so the iPad " +
+    "picks the change up on its next sync.",
+  {
+    habits: z
+      .array(z.string().min(1))
+      .max(20)
+      .describe('Habit names in display order, e.g. ["PT", "Water", "Read"]. [] clears them.'),
+  },
+  { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+  async ({ habits }) => {
+    try {
+      const root = await requireLibrary();
+      const written = await writeUnderlayHabits(root, habits);
+      return json({ ok: true, underlayHabits: written.length > 0 ? written : null });
+    } catch (e: any) {
       return { ...text(`Error: ${e.message}`), isError: true as const };
     }
   },
@@ -250,14 +280,7 @@ const HEX_COLOR = z
   .regex(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/, "must be a hex colour like #7B5EA7");
 
 // The closed set of fonts that render in-app (see svg.ts REGION_DEFAULTS).
-const FONT_ENUM = z.enum([
-  "Mulish",
-  "Newsreader",
-  "IBM Plex Mono",
-  "Caveat",
-  "Fredoka",
-  "Phosphor",
-]);
+const FONT_ENUM = z.enum(FONT_FAMILIES);
 
 // The confirmed-codepoint subset (see svg.ts PHOSPHOR_CODEPOINTS) — an icon name
 // outside this set is rejected here rather than silently rendering nothing.
@@ -569,10 +592,34 @@ server.tool(
               "pill on a banner theme (the label text is picked to read on it, and warns if " +
               "nothing clears 4.5:1); auto-darkened as the label text on an underline theme.",
           ),
+          labelStyle: z
+            .enum(["theme", "plain"])
+            .optional()
+            .describe(
+              "How the region title is drawn. 'theme' (default): the theme's heading style " +
+                "(pill or label+rule). 'plain': exactly what the app's on-device composer " +
+                "writes into a printed `label-*` slot — uppercase Mulish 12/700 in the accent, " +
+                "no pill — for visual parity with device-authored pages. Note the slot names: " +
+                "the todo template's columns are `list-1/2/3` but their slots are " +
+                "`label-list1/2/3` (no hyphen) — read_page's `labelSlot` already resolves this.",
+            ),
           lines: z
             .array(lineSchema)
             .optional()
-            .describe("Text lines to place in this region. Mutually exclusive with `calendar`/`svg`."),
+            .describe("Text lines to place in this region. Mutually exclusive with `calendar`/`svg`/`habits`."),
+          habits: z
+            .union([z.literal(true), z.array(z.string().min(1))])
+            .optional()
+            .describe(
+              "Draw the composer-parity HABITS block: one row per habit name — a 13px square " +
+                "checkbox + the name (Mulish 14), 21px pitch, titled 'Habits' via the region's " +
+                "`label-habits` slot when the template prints one. `true` = use the library's " +
+                "`settings.json → underlayHabits` (see get_library/read_page; set with " +
+                "set_habits); or pass the names. Meant for a region named `habits` (an " +
+                "imported/BYO template, or the catalogue once it ships one) — the same vector " +
+                "block the app draws on device, so NOT a raster sticker. Mutually exclusive " +
+                "with `lines`/`calendar`/`svg`.",
+            ),
           calendar: calendarSchema
             .optional()
             .describe(

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveRoot, sharedDir, normalizeChapter, resolvePageRel } from "./paths.js";
-import { type AiStatus, type Manifest, readIfExists } from "./page.js";
+import { type AiStatus, type Manifest, readIfExists, atomicWrite } from "./page.js";
 
 /**
  * The library's `settings.json → underlayVoice` (the app's `FORMAT.md §4` contract) —
@@ -38,6 +38,57 @@ export async function readUnderlayVoice(root: string): Promise<UnderlayVoice | n
   } catch {
     return null;
   }
+}
+
+/**
+ * Read `settings.json → underlayHabits` — the daily habit names the on-device composer
+ * renders as its `habits` block (app `UNDERLAY-AUTOFILL.md` / #170 P1; MCP issue #50).
+ * `[String]`, the explicit synced source (root `settings.json` rides iCloud). null when
+ * the file is absent/garbled or the key is missing/empty — "no habits block".
+ */
+export async function readUnderlayHabits(root: string): Promise<string[] | null> {
+  const raw = await readIfExists(path.join(root, "settings.json"));
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw)?.underlayHabits;
+    if (!Array.isArray(v)) return null;
+    const names = v.filter((h): h is string => typeof h === "string" && h.trim() !== "").map((h) => h.trim());
+    return names.length > 0 ? names : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write `settings.json → underlayHabits` (the ONE settings key this server writes — the
+ * contract says it is MCP read/writable). Read-modify-write: every other key is preserved
+ * byte-for-meaning; an absent file is created with just this key. Refuses to clobber a
+ * garbled file (the app rewrites settings wholesale and an unparseable one would be lost
+ * either way — but not by us). An empty list removes the key (= no habits block).
+ */
+export async function writeUnderlayHabits(root: string, habits: string[]): Promise<string[]> {
+  const file = path.join(root, "settings.json");
+  const raw = await readIfExists(file);
+  let settings: Record<string, unknown> = {};
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error("not an object");
+      }
+      settings = parsed;
+    } catch {
+      throw new Error(
+        `settings.json at ${file} is not valid JSON — refusing to overwrite it. Fix or remove ` +
+          `the file (the app re-creates a default one) and retry.`,
+      );
+    }
+  }
+  const names = habits.map((h) => h.trim()).filter((h) => h !== "");
+  if (names.length > 0) settings.underlayHabits = names;
+  else delete settings.underlayHabits;
+  await atomicWrite(file, JSON.stringify(settings, null, 2) + "\n");
+  return names;
 }
 
 /** Thrown when the iCloud library / Shared folder isn't present yet. */

--- a/src/page.ts
+++ b/src/page.ts
@@ -13,7 +13,7 @@ import {
   type Region,
   type TemplateInfo,
 } from "./template.js";
-import { readUnderlayVoice, type UnderlayVoice } from "./library.js";
+import { readUnderlayVoice, readUnderlayHabits, type UnderlayVoice } from "./library.js";
 import {
   composeAiSvg,
   mergeRegions,
@@ -272,7 +272,7 @@ async function sweepStaleTmp(absFile: string): Promise<void> {
 }
 
 /** Write a file atomically: temp sibling + rename, so no reader sees a partial file. */
-async function atomicWrite(absFile: string, content: string | Uint8Array): Promise<void> {
+export async function atomicWrite(absFile: string, content: string | Uint8Array): Promise<void> {
   await sweepStaleTmp(absFile);
   const tmp = `${absFile}.tmp-${process.pid}-${tmpCounter++}`;
   await fs.writeFile(tmp, content); // string defaults to utf8; Uint8Array writes bytes
@@ -938,6 +938,12 @@ export interface PageRead {
    * never writes settings.json.
    */
   underlayVoice: UnderlayVoice | null;
+  /**
+   * `settings.json → underlayHabits` — the habit names the on-device composer draws into
+   * a `habits` region; null when unset. Author the same list with a region entry
+   * `{ region: "habits", habits: true }` (#50). Written only via `set_habits`.
+   */
+  underlayHabits: string[] | null;
   templateSvg?: string;
 }
 
@@ -966,6 +972,7 @@ export async function readPage(
     ...(resolved.washiTint ? { washiTint: resolved.washiTint } : {}),
   };
   const underlayVoice = await readUnderlayVoice(root);
+  const underlayHabits = await readUnderlayHabits(root);
   // labelFilled: cross-reference each region's labelSlot geometry (template-only)
   // against what the current ai.svg actually drew for that region — geometry alone
   // can't tell you whether the AI filled the slot or the template just prints one.
@@ -995,6 +1002,7 @@ export async function readPage(
     theme,
     underlay,
     underlayVoice,
+    underlayHabits,
     ...(includeTemplate && templateSvg ? { templateSvg } : {}),
   };
 }
@@ -1205,6 +1213,20 @@ export async function writeUnderlay(
     // and fills each image's href, ahead of composeAiSvg.
     const templateSvg = await readIfExists(path.join(abs, "template.svg"));
     const regions = templateSvg ? parseRegions(templateSvg, manifest.template) : [];
+    // `habits: true` → the library's `settings.json → underlayHabits` (#50), resolved here
+    // so composeAiSvg stays pure. No configured habits is a caller error, not an empty block.
+    for (const r of opts.regions) {
+      if (r.habits === true) {
+        const list = await readUnderlayHabits(root);
+        if (!list) {
+          throw new Error(
+            `Region "${r.region}": \`habits: true\` but settings.json has no underlayHabits — ` +
+              `set them with set_habits first, or pass the names as \`habits: ["…"]\`.`,
+          );
+        }
+        r.habits = list;
+      }
+    }
     const imageResult = await resolveImages(
       abs,
       opts.regions,

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -409,7 +409,22 @@ interface RegionDefault {
    *  schedule needs a wider gutter so its text clears the printed hour labels. */
   xPad?: number;
 }
-const REGION_DEFAULTS: Record<string, RegionDefault> = {
+/**
+ * The closed in-app font set (the app bundles exactly these under
+ * `Onionskin/DesignSystem/Fonts/`; `Phosphor` is the retired icon face the renderer
+ * repaints as SF Symbols). `index.ts` builds the tool schema's enum from this and
+ * `test/parity.ts` diffs it against the app's bundled font files.
+ */
+export const FONT_FAMILIES = [
+  "Mulish",
+  "Newsreader",
+  "IBM Plex Mono",
+  "Caveat",
+  "Fredoka",
+  "Phosphor",
+] as const;
+
+export const REGION_DEFAULTS: Record<string, RegionDefault> = {
   ainotes: { font: "Newsreader", size: 16, weight: 500 }, // the serif AI-voice register
   header: { font: "Mulish", size: 20, weight: 700 },
   schedule: { font: "Mulish", size: 15, weight: 600, xPad: 52 },
@@ -418,6 +433,24 @@ const REGION_DEFAULTS: Record<string, RegionDefault> = {
   notes: { font: "Mulish", size: 14, weight: 600 },
   focus: { font: "Mulish", size: 15, weight: 600 },
   month: { font: "Mulish", size: 13, weight: 600 },
+  // The rest of the 2026-06 catalogue family (#49) — previously fell to FALLBACK_DEFAULT.
+  "list-1": { font: "Mulish", size: 15, weight: 600 }, // todo template's three columns
+  "list-2": { font: "Mulish", size: 15, weight: 600 },
+  "list-3": { font: "Mulish", size: 15, weight: 600 },
+  habits: { font: "Mulish", size: 14, weight: 500 }, // the composer's habits block (#50)
+  last: { font: "Newsreader", size: 15, weight: 500 }, // reflection's "from last session"
+  photos: { font: "Mulish", size: 13, weight: 600 }, // captions under photo slots
+  morning: { font: "Mulish", size: 15, weight: 600 }, // weekend day-parts
+  afternoon: { font: "Mulish", size: 15, weight: 600 },
+  evening: { font: "Mulish", size: 15, weight: 600 },
+  weekdays: { font: "Mulish", size: 13, weight: 800 }, // monthly's Sun–Sat header (printed)
+  page: { font: "Mulish", size: 14, weight: 600 }, // lined/dotted/blank surface (ink)
+  joys: { font: "Mulish", size: 14, weight: 600 }, // reflection prompts (ink)
+  concerns: { font: "Mulish", size: 14, weight: 600 },
+  memories: { font: "Mulish", size: 14, weight: 600 },
+  // `accent` is image-only (one sticker or tiny drawing, never text) — typography here is
+  // only so a stray line still renders; composeAiSvg warns `accent_text` for it.
+  accent: { font: "Mulish", size: 12, weight: 600 },
   // legacy region names (retired 2026-06) — kept so older pages still style correctly.
   quote: { font: "Newsreader", size: 16, weight: 500 },
   affirmation: { font: "Newsreader", size: 16, weight: 500 },
@@ -656,8 +689,25 @@ export interface RegionInput {
   label?: string;
   /** Override the label banner color (defaults to the theme's cycled banner color). */
   labelFill?: string;
-  /** Text lines (ruled/box regions). Mutually exclusive with `calendar`/`svg`. */
+  /**
+   * How the region title is drawn (#49). Default = the theme's heading style (a coloured
+   * pill on `banner` themes, label + rule on `underline`). `"plain"` matches the app's
+   * on-device composer exactly — Mulish 12 / 700 / uppercase in the theme accent, at the
+   * printed `label-*` slot's origin (`x+2`, `y+min(height−4,16)`), no pill, no rule.
+   */
+  labelStyle?: "theme" | "plain";
+  /** Text lines (ruled/box regions). Mutually exclusive with `calendar`/`svg`/`habits`. */
   lines?: LineInput[];
+  /**
+   * Render the composer-parity **habits** block (#50): one row per habit name — a 13px
+   * `rx 2` square at `x+6` and the name in Mulish 14 at `x+26`, first baseline `y+18`,
+   * 21px pitch, stopping at the region height (`habits_overflow` warns). `true` means
+   * "the library's `settings.json → underlayHabits`" — `page.ts` resolves it to the
+   * list before compose; `composeAiSvg` itself only accepts the resolved `string[]`.
+   * Meant for a region named `habits` (titled via its `label-habits` slot when present).
+   * Mutually exclusive with `lines`/`calendar`/`svg`.
+   */
+  habits?: string[] | true;
   /** Calendar grid (the month region). Mutually exclusive with `lines`/`svg`. */
   calendar?: CalendarSpec;
   /**
@@ -1396,10 +1446,17 @@ export function composeAiSvg(
       input.lines !== undefined ? "lines" : null,
       input.calendar !== undefined ? "calendar" : null,
       input.svg !== undefined ? "svg" : null,
+      input.habits !== undefined ? "habits" : null,
     ].filter(Boolean);
+    if (input.habits === true) {
+      throw new Error(
+        `Region "${input.region}": \`habits: true\` must be resolved to the settings list ` +
+          `before compose (write_underlay does this; pass the names directly here).`,
+      );
+    }
     if (bodyKinds.length > 1) {
       throw new Error(
-        `Region "${input.region}": provide only one of \`lines\`, \`calendar\`, or ` +
+        `Region "${input.region}": provide only one of \`lines\`, \`calendar\`, \`habits\`, or ` +
           `\`svg\` (got ${bodyKinds.join(" + ")}).`,
       );
     }
@@ -1411,24 +1468,39 @@ export function composeAiSvg(
     // at it instead of the default margin position — banner style fills the slot's box
     // exactly; underline style just anchors its text off the slot's origin (it draws no
     // box of its own, so there's nothing to stretch).
-    if (input.label) {
+    // A habits region with a printed `label-habits` slot titles itself the way the
+    // on-device composer does ("Habits", plain) unless the caller passed a label (#50).
+    const effLabel =
+      input.label ?? (Array.isArray(input.habits) && region.labelSlot ? "Habits" : undefined);
+    const effLabelStyle = input.labelStyle ?? (input.label === undefined && effLabel ? "plain" : "theme");
+    if (effLabel) {
       const lsize = 15;
       const slot = region.labelSlot;
-      const lw = bannerLabelWidth(input.label, lsize);
+      const lw = bannerLabelWidth(effLabel, lsize);
       const labelFont = themeFontFor(theme, region.name, true) ?? "Mulish";
       // A printed slot sits inside the region's authored space, so it can't be
       // off-page by construction — only check the fallback margin placement.
       if (!slot && region.y - 12 - lsize < 0) {
         warn(
           "label_above_page",
-          `region "${region.name}": label "${truncate(input.label)}" may sit above the page top.`,
+          `region "${region.name}": label "${truncate(effLabel)}" may sit above the page top.`,
           "warning",
           region.name,
         );
       }
       const lx = slot ? slot.x : DEFAULT_X_PAD;
       const ly = slot ? slot.y + slot.height - Math.round(slot.height * 0.28) : -12;
-      if (theme.headingStyle === "banner") {
+      if (effLabelStyle === "plain") {
+        // Composer parity (`UnderlaySVGComposer.sectionLabel`): uppercase Mulish 12 / 700
+        // in the accent, anchored at the slot's origin — no pill, no rule.
+        const px = slot ? slot.x + 2 : DEFAULT_X_PAD;
+        const py = slot ? slot.y + (slot.height > 0 ? Math.min(slot.height - 4, 16) : 16) : -12;
+        const pfill = input.labelFill !== undefined ? floorTextFill(input.labelFill) : theme.accent;
+        parts.push(
+          `    <text x="${px}" y="${py}" font-family="Mulish" font-size="12" font-weight="700" ` +
+            `fill="${pfill}">${escapeXml(effLabel.toUpperCase())}</text>`,
+        );
+      } else if (theme.headingStyle === "banner") {
         const padX = BANNER_PAD_X;
         const bh = slot ? slot.height : Math.round(lsize * 1.15) + 6;
         const by = slot ? slot.y : ly - Math.round(lsize * 0.82) - 3;
@@ -1441,13 +1513,13 @@ export function composeAiSvg(
         );
         parts.push(
           `    <text x="${lx + padX}" y="${ly}" font-family="${escapeXml(labelFont)}" font-size="${lsize}" ` +
-            `font-weight="800" letter-spacing="0.1em" fill="${labelText}">${escapeXml(input.label)}</text>`,
+            `font-weight="800" letter-spacing="0.1em" fill="${labelText}">${escapeXml(effLabel)}</text>`,
         );
       } else {
         const lfill = input.labelFill !== undefined ? floorTextFill(input.labelFill) : theme.text;
         parts.push(
           `    <text x="${lx}" y="${ly}" font-family="${escapeXml(labelFont)}" font-size="${lsize}" ` +
-            `font-weight="800" letter-spacing="0.1em" fill="${lfill}">${escapeXml(input.label)}</text>`,
+            `font-weight="800" letter-spacing="0.1em" fill="${lfill}">${escapeXml(effLabel)}</text>`,
         );
         parts.push(
           `    <line x1="${lx}" y1="${ly + 4}" x2="${lx + lw + 18}" y2="${ly + 4}" ` +
@@ -1594,6 +1666,47 @@ export function composeAiSvg(
         }
         parts.push(`    ${frag}`);
       }
+    } else if (Array.isArray(input.habits)) {
+      // Composer-parity habits block (#50; `UnderlaySVGComposer.habitsGroup`): one row per
+      // habit, a square checkbox + the name, region-local. Geometry mirrors the app so a
+      // page authored here and one authored on device look the same.
+      const hSize = 14;
+      const hLineH = Math.round(hSize * 1.5); // 21
+      const hBox = Math.round(hSize * 0.9); // 13
+      const hLabelX = 6 + hBox + 7; // 26
+      let hy = 18;
+      let drawn = 0;
+      for (const name of input.habits) {
+        if (region.height !== null && hy > region.height) break;
+        parts.push(
+          `    <rect x="6" y="${hy - hBox}" width="${hBox}" height="${hBox}" rx="2" ` +
+            `fill="none" stroke="${theme.text}" stroke-width="1"/>`,
+        );
+        parts.push(
+          `    <text x="${hLabelX}" y="${hy}" font-family="Mulish" font-size="${hSize}" ` +
+            `font-weight="500" fill="${theme.text}">${escapeXml(name)}</text>`,
+        );
+        hy += hLineH;
+        drawn++;
+      }
+      if (drawn < input.habits.length) {
+        warn(
+          "habits_overflow",
+          `region "${region.name}": ${input.habits.length - drawn} of ${input.habits.length} ` +
+            `habits don't fit the ${region.height}px box — only the first ${drawn} drawn.`,
+          "warning",
+          region.name,
+        );
+      }
+      if (region.name !== "habits") {
+        warn(
+          "habits_region_name",
+          `region "${region.name}": the habits block is meant for a region named "habits" ` +
+            `(the on-device composer only renders habits there) — drawn here as asked.`,
+          "info",
+          region.name,
+        );
+      }
     } else if (input.calendar) {
       parts.push(
         ...composeCalendar(region, input.calendar, theme, (days) => {
@@ -1681,6 +1794,21 @@ export function composeAiSvg(
       // baseline y -> the text of the `lines[]` entry that owns it (row_collision, #30).
       const baselineOwners = new Map<number, string>();
       let handwritingWarned = false;
+      // `accent` is the catalogue's universal decorative pocket — "one sticker or tiny
+      // drawing, never text, ok to leave empty" (#49).
+      if (region.name === "accent" && lines.length > 0) {
+        warn(
+          "accent_text",
+          `region "accent": ${lines.length} text line(s) given — the accent pocket is for one ` +
+            `small sticker/drawing, never text (drawn anyway; consider an \`images\` entry).`,
+          "warning",
+          region.name,
+        );
+      }
+      // Header composition parity (#48): when art fills the header's slot, the date /
+      // eyebrow text must clear it — the composer reserves the slot plus 12px.
+      const artClearX =
+        region.artSlot && imageRects.length > 0 ? region.artSlot.x - 12 : null;
       lines.forEach((line, i) => {
         const size = line.size ?? def.size;
         const font = line.font ?? themeFontFor(theme, region.name, !!line.heading) ?? def.font;
@@ -2023,14 +2151,15 @@ export function composeAiSvg(
         // Available width is box-relative: from the inset to the right edge when
         // left-aligned; symmetric about the centre; from the left inset to the anchor
         // when right-aligned.
+        const rightEdge = artClearX !== null ? Math.min(region.width ?? artClearX, artClearX) : region.width;
         const maxWidth =
-          region.width === null
+          rightEdge === null
             ? null
             : align === "center"
-              ? region.width - 2 * xPadR
+              ? rightEdge - 2 * xPadR
               : align === "right"
                 ? anchorX - xPadR
-                : region.width - x;
+                : rightEdge - x;
         const segments =
           effWrap && maxWidth !== null && maxWidth > 0
             ? wrapText(line.text, font, size, maxWidth)
@@ -2141,6 +2270,7 @@ export function composeAiSvg(
       !input.label &&
       (input.images?.length ?? 0) === 0 &&
       input.calendar === undefined &&
+      input.habits === undefined &&
       (input.svg === undefined || input.svg.trim() === "") &&
       (input.lines?.length ?? 0) === 0 &&
       !hourLabelsDrawn;

--- a/src/template.ts
+++ b/src/template.ts
@@ -262,11 +262,12 @@ export function parseViewBox(templateSvg: string): [number, number] | null {
  * shipped templates (`../onionskin/.../Templates/`). Unknown names fall through to
  * template-type, then geometry (see deriveFill).
  */
-const FILL_BY_NAME: Record<string, RegionFill> = {
+export const FILL_BY_NAME: Record<string, RegionFill> = {
   // shared — AI seeds (calendar/tasks), the user augments by hand on top.
   schedule: "shared",
   agenda: "shared",
   todo: "shared",
+  habits: "shared", // the composer's habits block — AI draws boxes, the user checks them (#50)
   "list-1": "shared",
   "list-2": "shared",
   "list-3": "shared",
@@ -280,6 +281,7 @@ const FILL_BY_NAME: Record<string, RegionFill> = {
   ainotes: "ai", // the AI voice: weather/context/affirmation + a home for a small image
   last: "ai", // reflection's "from last session" — the AI surfaces it
   header: "ai",
+  accent: "ai", // every template's small decorative pocket — one sticker, never text (#49)
   // The monthly templates print Sun–Sat themselves — nothing for the AI to own here
   // (an `ai` default invited double-printing the weekday header).
   weekdays: "shared",

--- a/test/cli.ts
+++ b/test/cli.ts
@@ -15,7 +15,7 @@
  * A Bash-spawned process inherits the host's Full Disk Access, so live reads/writes
  * work here without reconnecting the registered server.
  */
-import { requireLibrary, listChapters, listPageRows, type PageFilter } from "../src/library.js";
+import { requireLibrary, listChapters, listPageRows, writeUnderlayHabits, type PageFilter } from "../src/library.js";
 import {
   readPage,
   readInk,
@@ -47,7 +47,7 @@ async function main() {
         "Tools: get_library | list_pages [chapter] [key=value filters] | read_page <page> [--template] |\n" +
         "  read_ink <page> | write_underlay <page> <json> | set_underlay_status <page> <status> |\n" +
         "  clear_underlay <page> | create_page <json> | set_chapter_theme <chapter> <json> |\n" +
-        "  fetch_image <json:{url,name?}>",
+        "  set_habits <json:[names]> | fetch_image <json:{url,name?}>",
     );
   }
 
@@ -133,6 +133,13 @@ async function main() {
       if (!args[0]) throw new Error("set_chapter_theme needs <chapter> <json>.");
       const body = parseJson(args[1], "theme");
       return out({ ok: true, ...(await writeChapterTheme(root, args[0], body)) });
+    }
+
+    case "set_habits": {
+      // args: <json:["PT","Water",...]>  ([] clears)
+      const body = parseJson(args[0], "habits");
+      if (!Array.isArray(body)) throw new Error("set_habits needs a JSON array of habit names.");
+      return out({ ok: true, underlayHabits: await writeUnderlayHabits(root, body) });
     }
 
     case "fetch_image": {

--- a/test/parity.ts
+++ b/test/parity.ts
@@ -1,0 +1,116 @@
+/**
+ * Parity guard (#41, #51): this server hand-mirrors several tables the app owns — region
+ * names + fills, the closed font set, the Phosphor codepoints, the renderer's element set.
+ * Nothing in the runtime can notice when they drift (a wrong codepoint renders tofu on
+ * device, a renamed region silently falls to fallback typography). This diffs each mirror
+ * against its source of truth in the sibling `../onionskin` checkout and fails loudly.
+ *
+ * Run by `npm run smoke` after the e2e suite. Skips cleanly (exit 0, with a notice) when
+ * the sibling checkout is absent — the same dependency the smoke copy already has.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { PHOSPHOR_CODEPOINTS, RAW_SVG_ALLOWED_ELEMENTS, REGION_DEFAULTS, FONT_FAMILIES } from "../src/svg.js";
+import { FILL_BY_NAME } from "../src/template.js";
+
+const APP = process.env.ONIONSKIN_APP_REPO ?? path.resolve(process.cwd(), "..", "onionskin");
+
+let pass = 0;
+let fail = 0;
+function check(name: string, ok: boolean, detail?: string) {
+  if (ok) pass++;
+  else fail++;
+  console.log(`  ${ok ? "✓" : "✗"} ${name}${!ok && detail ? ` — ${detail}` : ""}`);
+}
+
+async function exists(p: string): Promise<boolean> {
+  return fs
+    .stat(p)
+    .then(() => true)
+    .catch(() => false);
+}
+
+async function main() {
+  if (!(await exists(path.join(APP, "Onionskin")))) {
+    console.log(`parity: sibling app checkout not found at ${APP} — skipping (set ONIONSKIN_APP_REPO).`);
+    return;
+  }
+  console.log(`Parity against ${APP}\n`);
+
+  // 1. Phosphor codepoints vs the app's private `legacyScalar` switch.
+  console.log("PHOSPHOR_CODEPOINTS ↔ DesignSystem/Phosphor.swift legacyScalar");
+  const phosphor = await fs.readFile(path.join(APP, "Onionskin", "DesignSystem", "Phosphor.swift"), "utf8");
+  const scalarBlock = phosphor.slice(phosphor.indexOf("var legacyScalar"));
+  const appCodepoints = new Map<string, string>();
+  for (const m of scalarBlock.matchAll(/case \.(\w+):\s+return "\\u\{([0-9a-fA-F]+)\}"/g)) {
+    appCodepoints.set(m[1], String.fromCodePoint(parseInt(m[2], 16)));
+  }
+  check("parsed the app's legacyScalar table", appCodepoints.size >= 20, `${appCodepoints.size} entries`);
+  for (const [name, ch] of Object.entries(PHOSPHOR_CODEPOINTS)) {
+    const app = appCodepoints.get(name);
+    check(
+      `icon "${name}" exists in the app with the same codepoint`,
+      app !== undefined && app === ch,
+      app === undefined
+        ? "not in the app's enum"
+        : `ours U+${ch.codePointAt(0)!.toString(16)} vs app U+${app.codePointAt(0)!.toString(16)}`,
+    );
+  }
+  const unmirrored = [...appCodepoints.keys()].filter((n) => !(n in PHOSPHOR_CODEPOINTS));
+  if (unmirrored.length) console.log(`  (info) app glyphs not mirrored here: ${unmirrored.join(", ")}`);
+
+  // 2. Region vocabulary vs the shipped catalogue.
+  console.log("\nFILL_BY_NAME / REGION_DEFAULTS ↔ Fixtures/Library/Templates/*/template.svg");
+  const templatesDir = path.join(APP, "Onionskin", "Fixtures", "Library", "Templates");
+  const ids = (await fs.readdir(templatesDir, { withFileTypes: true })).filter((d) => d.isDirectory()).map((d) => d.name);
+  check("catalogue has templates", ids.length >= 20, `${ids.length}`);
+  const seen = new Map<string, { fill: string | null; templates: Set<string> }>();
+  for (const id of ids) {
+    const svg = await fs.readFile(path.join(templatesDir, id, "template.svg"), "utf8");
+    for (const tag of svg.matchAll(/<(?:g|rect)\b[^>]*\bdata-region="([^"]+)"[^>]*>/g)) {
+      const name = tag[1];
+      if (name.startsWith("label-") || name.startsWith("art-")) continue; // sub-boxes, not regions
+      const fill = /\bdata-fill="([^"]+)"/.exec(tag[0])?.[1] ?? null;
+      const e = seen.get(name) ?? { fill, templates: new Set() };
+      if (e.fill !== fill && fill !== null) e.fill = fill;
+      e.templates.add(id);
+      seen.set(name, e);
+    }
+  }
+  for (const [name, e] of [...seen.entries()].sort()) {
+    const known = name in FILL_BY_NAME;
+    const styled = name in REGION_DEFAULTS;
+    check(`region "${name}" (${e.templates.size} templates) is known to FILL_BY_NAME + REGION_DEFAULTS`, known && styled, `FILL_BY_NAME:${known} REGION_DEFAULTS:${styled}`);
+    if (known && e.fill) {
+      check(`region "${name}" fill default (${FILL_BY_NAME[name]}) matches the catalogue's data-fill (${e.fill})`, FILL_BY_NAME[name] === e.fill);
+    }
+  }
+  const legacyOnly = Object.keys(FILL_BY_NAME).filter((n) => !seen.has(n));
+  if (legacyOnly.length) console.log(`  (info) MCP-only / legacy region names (no shipped template): ${legacyOnly.join(", ")}`);
+
+  // 3. Raw-svg element allowlist ⊆ the app parser's element switch.
+  console.log("\nRAW_SVG_ALLOWED_ELEMENTS ⊆ SVG/SVGParser.swift element cases");
+  const parser = await fs.readFile(path.join(APP, "Onionskin", "SVG", "SVGParser.swift"), "utf8");
+  const parserCases = new Set([...parser.matchAll(/case "([a-zA-Z]+)"/g)].map((m) => m[1]));
+  for (const el of RAW_SVG_ALLOWED_ELEMENTS) {
+    check(`element <${el}> is parsed by the app`, parserCases.has(el), `app parser cases: ${[...parserCases].join(", ")}`);
+  }
+
+  // 4. Closed font set ⊆ the app's bundled font files (Phosphor is the retired icon face,
+  //    repainted as SF Symbols — no file by design).
+  console.log("\nFONT_FAMILIES ⊆ DesignSystem/Fonts/*.ttf");
+  const fontFiles = (await fs.readdir(path.join(APP, "Onionskin", "DesignSystem", "Fonts"))).map((f) => f.toLowerCase());
+  for (const family of FONT_FAMILIES) {
+    if (family === "Phosphor") continue;
+    const stem = family.replace(/\s+/g, "").toLowerCase();
+    check(`font "${family}" is bundled by the app`, fontFiles.some((f) => f.startsWith(stem)), `files: ${fontFiles.join(", ")}`);
+  }
+
+  console.log(`\nparity: ${pass} passed, ${fail} failed`);
+  process.exit(fail === 0 ? 0 : 1);
+}
+
+main().catch((e) => {
+  console.error("Parity check crashed:", e);
+  process.exit(1);
+});

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -20,6 +20,8 @@ import {
   listPages,
   listPageRows,
   readUnderlayVoice,
+  readUnderlayHabits,
+  writeUnderlayHabits,
   LibraryMissingError,
 } from "../src/library.js";
 import {
@@ -32,7 +34,7 @@ import {
   writeChapterTheme,
   fetchImageToTemp,
 } from "../src/page.js";
-import { resolveTheme, composeAiSvg, PHOSPHOR_CODEPOINTS, scanRawSvgDataUriImages } from "../src/svg.js";
+import { resolveTheme, composeAiSvg, PHOSPHOR_CODEPOINTS, scanRawSvgDataUriImages, REGION_DEFAULTS } from "../src/svg.js";
 import {
   hexToHsl,
   contrastRatioHex,
@@ -41,7 +43,7 @@ import {
   monthlyInks,
   PALETTE_CHARACTERS,
 } from "../src/color.js";
-import { inspectTemplate, parseRegions, PAPER_COLOR } from "../src/template.js";
+import { inspectTemplate, parseRegions, PAPER_COLOR, FILL_BY_NAME } from "../src/template.js";
 import { decodePng, encodePng, chromaKeyPixels } from "../src/png.js";
 
 // Gold is retired — the default (no theme override) resolves to the chapter's own ink
@@ -1490,6 +1492,52 @@ async function main() {
   });
   check("default Mulish 15 body text trips neither typography warning", !cleanTypo.warningDetails.some((w) => w.code === "text_too_small" || w.code === "handwriting_body_font"), JSON.stringify(cleanTypo.warnings));
 
+  console.log("\n#50 habits (settings.json ↔ vector block); #49 accent + plain labels; #48 header art clearance");
+  check("no underlayHabits → null", (await readUnderlayHabits(root)) === null);
+  await fs.writeFile(settingsPath, JSON.stringify({ underlayVoice: { name: "B" }, pencil: { smoothing: 0.6 } }));
+  const habitsWritten = await writeUnderlayHabits(root, ["PT", " Water ", "", "Read"]);
+  check("set_habits trims/drops blanks and returns the list", JSON.stringify(habitsWritten) === JSON.stringify(["PT", "Water", "Read"]), JSON.stringify(habitsWritten));
+  const settingsAfter = JSON.parse(await fs.readFile(settingsPath, "utf8"));
+  check("other settings keys survive the habits write", settingsAfter.underlayVoice?.name === "B" && settingsAfter.pencil?.smoothing === 0.6, JSON.stringify(settingsAfter));
+  check("read_page surfaces underlayHabits", JSON.stringify((await readPage(root, daily)).underlayHabits) === JSON.stringify(["PT", "Water", "Read"]));
+  // A BYO template with a `habits` region + label-habits slot (no catalogue template ships one yet).
+  const habitsTpl = parseRegions('<svg viewBox="0 0 1024 1366" xmlns="http://www.w3.org/2000/svg"><g id="region-habits" data-region="habits" data-fill="shared" transform="translate(100,900)"><rect x="0" y="0" width="280" height="50" fill="none"/><rect x="0" y="-40" width="100" height="30" data-region="label-habits" stroke-dasharray="3 5"/></g></svg>');
+  const habitsOut = composeAiSvg([1024, 1366], [{ region: "habits", habits: ["PT", "Water", "Read"] }], habitsTpl);
+  const habitsGroup = regionGroup(habitsOut.svg, "habits") ?? "";
+  const habitBoxes = [...habitsGroup.matchAll(/<rect x="6" y="(\d+)" width="13" height="13" rx="2"/g)].map((m) => Number(m[1]));
+  check("habits block draws a 13px rx2 square per habit at x=6 (composer geometry)", habitBoxes.length === 2, JSON.stringify(habitBoxes));
+  check("habit rows start at baseline 18 and pitch 21 (boxes at y=5, 26)", habitBoxes[0] === 5 && habitBoxes[1] === 26, JSON.stringify(habitBoxes));
+  check("habit names are Mulish 14 at x=26", /<text x="26" y="18" font-family="Mulish" font-size="14"[^>]*>PT<\/text>/.test(habitsGroup), habitsGroup.slice(0, 300));
+  check("a 50px-tall box fits 2 of 3 habits and warns habits_overflow", habitsOut.warningDetails.some((w) => w.code === "habits_overflow" && w.message.includes("1 of 3")), JSON.stringify(habitsOut.warnings));
+  check("the label-habits slot is titled HABITS in the composer's plain style", /<text x="2" y="-24" font-family="Mulish" font-size="12" font-weight="700"[^>]*>HABITS<\/text>/.test(habitsGroup), habitsGroup.slice(0, 400));
+  check("habits: true is rejected by composeAiSvg (must be resolved by write_underlay)", (() => { try { composeAiSvg([1024, 1366], [{ region: "habits", habits: true }], habitsTpl); return false; } catch { return true; } })());
+  let habitsAndLines = false;
+  try { composeAiSvg([1024, 1366], [{ region: "habits", habits: ["PT"], lines: [{ text: "x" }] }], habitsTpl); } catch { habitsAndLines = true; }
+  check("habits is mutually exclusive with lines", habitsAndLines);
+  // write_underlay resolves `habits: true` from settings.json — the daily page has no habits
+  // region, so drive a todo region (info-flagged habits_region_name) to exercise the path.
+  const habitsLive = await writeUnderlay(root, daily, { status: "ready", dryRun: true, regions: [{ region: "todo", habits: true }] });
+  check("write_underlay resolves habits:true from settings.json (3 rows drawn)", (regionGroup(habitsLive.aiSvg, "todo") ?? "").split("<rect").length - 1 === 3, JSON.stringify(habitsLive.warnings));
+  check("a habits block outside a `habits` region is info-flagged habits_region_name", habitsLive.warningDetails.some((w) => w.code === "habits_region_name" && w.severity === "info"));
+  await writeUnderlayHabits(root, []);
+  check("set_habits [] removes the key", !("underlayHabits" in JSON.parse(await fs.readFile(settingsPath, "utf8"))));
+  let habitsMissing = false;
+  try { await writeUnderlay(root, daily, { status: "ready", dryRun: true, regions: [{ region: "todo", habits: true }] }); } catch (e: any) { habitsMissing = /set_habits/.test(e.message); }
+  check("habits:true with no configured habits is a clear error naming set_habits", habitsMissing);
+  await fs.writeFile(settingsPath, "{ not json");
+  let garbledRefused = false;
+  try { await writeUnderlayHabits(root, ["PT"]); } catch { garbledRefused = true; }
+  check("set_habits refuses to overwrite a garbled settings.json", garbledRefused);
+  await fs.rm(settingsPath, { force: true });
+  // #49 — accent is image-only; the 2026-06 family has real defaults; plain label style.
+  const accentText = await writeUnderlay(root, daily, { status: "ready", dryRun: true, regions: [{ region: "accent", lines: [{ text: "no text here" }] }] });
+  check("text in the accent pocket warns accent_text", accentText.warningDetails.some((w) => w.code === "accent_text"), JSON.stringify(accentText.warnings));
+  check("accent / list-1 / morning / last have explicit REGION_DEFAULTS (no fallback typography)", ["accent", "list-1", "morning", "last", "habits", "photos"].every((n) => n in REGION_DEFAULTS));
+  check("accent derives fill ai; habits derives shared (FILL_BY_NAME)", FILL_BY_NAME.accent === "ai" && FILL_BY_NAME.habits === "shared");
+  const plainLabel = await writeUnderlay(root, daily, { status: "ready", dryRun: true, regions: [{ region: "schedule", label: "Schedule", labelStyle: "plain", lines: [{ text: "x", row: 1 }] }] });
+  const plainGroup = regionGroup(plainLabel.aiSvg, "schedule") ?? "";
+  const schedSlot = schedule!.labelSlot!;
+  check("labelStyle plain writes uppercase Mulish 12/700 at the slot origin (composer sectionLabel)", plainGroup.includes(`<text x="${schedSlot.x + 2}" y="${schedSlot.y + Math.min(schedSlot.height - 4, 16)}" font-family="Mulish" font-size="12" font-weight="700"`) && plainGroup.includes(">SCHEDULE</text>") && !/<rect[^>]*rx="6"/.test(plainGroup), plainGroup.slice(0, 300));
   console.log("\n#43: minting a YYYY-MM chapter stamps year/month (no title); order is chronological");
   await createPage(root, { chapter: "2026-09", name: "2026-09-15", template: "daily-minimal" });
   const m43FolderFile = path.join(root, "Shared", "2026-09", ".folder.json");
@@ -1680,6 +1728,17 @@ async function main() {
   check("header text with no image info-flags art_slot_unfilled", textOnlyHdr.warningDetails.some((w) => w.code === "art_slot_unfilled" && w.severity === "info"), JSON.stringify(textOnlyHdr.warnings));
   check("a header with a banner does not flag art_slot_unfilled", !contain.warningDetails.some((w) => w.code === "art_slot_unfilled"));
   check("a region with no art slot never flags art_slot_unfilled", !footer.warningDetails.some((w) => w.code === "art_slot_unfilled"));
+  // #48 — header text wraps clear of the art slot when a banner fills it.
+  const hdrRead = await readPage(root, hdrPage);
+  const hdrSlot = hdrRead.regions.find((r) => r.name === "header")!.artSlot!;
+  const longDate = "Thursday, August 20 — a long header line that would otherwise run right under the banner art on the right, and keeps going with an eyebrow-length story about the day so the wrap width difference shows";
+  const hdrWithArt = await writeUnderlay(root, hdrPage, { status: "ready", dryRun: true, regions: [{ region: "header", images: [{ data: wideSrc, format: "png", fit: "contain" }], lines: [{ text: longDate, wrap: true }] }] });
+  const hdrTexts = [...(regionGroup(hdrWithArt.aiSvg, "header") ?? "").matchAll(/<text[^>]*>([^<]*)<\/text>/g)].map((m) => m[1]);
+  check("header text wraps to clear the filled art slot (several segments, none competing)", hdrTexts.length > 1 && !hdrWithArt.warningDetails.some((w) => w.code === "image_competes_with_text"), JSON.stringify({ hdrTexts, warnings: hdrWithArt.warnings, slotX: hdrSlot.x }));
+  const hdrNoArt = await writeUnderlay(root, hdrPage, { status: "ready", dryRun: true, regions: [{ region: "header", lines: [{ text: longDate, wrap: true }] }] });
+  const hdrNoArtTexts = [...(regionGroup(hdrNoArt.aiSvg, "header") ?? "").matchAll(/<text[^>]*>([^<]*)<\/text>/g)].map((m) => m[1]);
+  check("without art the same line uses the full band (fewer segments)", hdrNoArtTexts.length < hdrTexts.length, `${hdrNoArtTexts.length} vs ${hdrTexts.length}`);
+
 
   console.log("\nwrite_underlay images via local file `path` (no base64 through context)");
   const srcPng = path.join(os.tmpdir(), "onionskin-smoke-src.png");

--- a/test/smoke.ts
+++ b/test/smoke.ts
@@ -156,13 +156,15 @@ async function main() {
   check("schedule region parsed with ruled lines", (schedule?.ruledLines.length ?? 0) >= 8, String(schedule?.ruledLines.length));
   check("ainotes region parsed (no-ruled box)", !!ainotes && ainotes.ruledLines.length === 0, String(ainotes?.ruledLines.length));
   check("todo region parsed", !!todo);
-  // imageFloor: ainotes' own intent mentions "a habit sticker" — the interactive floor
-  // (245×245) applies regardless of the box size; todo's intent doesn't, so it gets the
-  // default 35%-of-box heuristic instead.
+  // imageFloor: the region whose intent mentions a habit (the `habits` region on catalogue
+  // ≥ 15-habits-region; `ainotes`' "a habit sticker" before it) gets the interactive floor
+  // (245×245) regardless of box size; todo's intent doesn't, so it gets the default
+  // 35%-of-box heuristic instead. Derived from the parsed intent, not a template-id list.
+  const habitIntentRegion = read.regions.find((r) => /\bhabit\b/i.test(r.intent ?? ""));
   check(
-    "ainotes' intent marks it interactive -> a 245×245 imageFloor",
-    ainotes?.imageFloor?.interactive === true && ainotes.imageFloor.width === 245 && ainotes.imageFloor.height === 245,
-    JSON.stringify(ainotes?.imageFloor),
+    "a region whose intent mentions a habit is interactive -> a 245×245 imageFloor",
+    habitIntentRegion?.imageFloor?.interactive === true && habitIntentRegion.imageFloor.width === 245 && habitIntentRegion.imageFloor.height === 245,
+    JSON.stringify({ region: habitIntentRegion?.name, floor: habitIntentRegion?.imageFloor }),
   );
   check(
     "todo's intent (task checkbox rows, not an image) -> the default 35%-of-box floor",
@@ -1914,12 +1916,12 @@ async function main() {
     floating.warningDetails.some((w) => w.code === "image_small_for_region" && w.severity === "info"), JSON.stringify(floating.warningDetails));
   check("the same tiny image corner-placed stays quiet (deliberate accent)",
     !cleanImg.warningDetails.some((w) => w.code === "image_small_for_region"), JSON.stringify(cleanImg.warningDetails));
-  // ainotes' box is 289×422 — the old 35%-of-box heuristic (~101×148) would NOT have
-  // flagged a 150×150 centered image, but its intent ("a habit sticker") now carries the
-  // declared 245×245 interactive floor, which does.
+  // The habit-intent region's box (289×240+ on the current catalogue) — the old 35%-of-box
+  // heuristic would NOT have flagged a 150×150 centered image, but its intent carries the
+  // declared 245×245 interactive floor, which does. (Region derived from intent — see above.)
   const habitSized = await writeUnderlay(root, daily, {
     status: "ready", dryRun: true,
-    regions: [{ region: "ainotes", images: [{ data: PNG_1x1, format: "png", name: "habit", width: 150, height: 150, corner: "center" }] }],
+    regions: [{ region: habitIntentRegion!.name, images: [{ data: PNG_1x1, format: "png", name: "habit", width: 150, height: 150, corner: "center" }] }],
   });
   check(
     "a habit-tracker-sized image below the 245px interactive floor still warns, even though it clears the old 35%-of-box heuristic",


### PR DESCRIPTION
Stacked on #56.

## Summary
- **#50 (MCP half)** new `set_habits` tool writes `settings.json → underlayHabits` (only that key; read-modify-write; garbled file refused); `get_library`/`read_page` surface it; `regions[].habits: true | string[]` draws the on-device composer's vector habits block (13px squares, Mulish 14, 21px pitch, `habits_overflow`), self-titled via a `label-habits` slot. Catalogue `habits` region ships app-side (onionskin#225) — #50 stays open until then.
- **#49** `accent` (+ `accent_text`), `habits`, `list-1/2/3`, `last`, `photos`, day-parts, `weekdays`, `page`, reflection prompts added to `REGION_DEFAULTS`/`FILL_BY_NAME`; `labelStyle: "plain"` = the composer's `sectionLabel` look.
- **#48** header text wraps to clear a filled art slot by 12px; header recipe documented with the composer's numbers.
- **#41/#51** `test/parity.ts` (run by `npm run smoke`, skips without `../onionskin`): Phosphor codepoints, catalogue regions/fills, renderer elements, bundled fonts — 84 checks, all passing today.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run smoke` — 438 passed, 0 failed; parity 84 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEFvwptDc4jKCm5UXRK43k